### PR TITLE
Rename package: sdk-core (instead of erdjs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Build and Test erdjs
+name: Build and Test
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-erdjs:
+  build:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-not-main.yml
+++ b/.github/workflows/publish-not-main.yml
@@ -1,7 +1,15 @@
-name: Publish erdjs
+name: Publish (not main)
 
 on:
   workflow_dispatch:
+    inputs:
+      channel:
+        type: choice
+        description: NPM channel
+        options: 
+        - alpha
+        - beta
+        - previous
 
 permissions:
   contents: write
@@ -21,12 +29,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_TAG=v$(node -p "require('./package.json').version")
-          gh release create $RELEASE_TAG --target=$GITHUB_SHA --title="$RELEASE_TAG" --generate-notes
-      
+          gh release create --prerelease $RELEASE_TAG --target=$GITHUB_SHA --title="$RELEASE_TAG" --generate-notes
+
       - run: npm ci
       - run: npm test
       
       - name: Publish to npmjs
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: npm publish --access=public
+        run: npm publish --access=public --tag=${{ github.event.inputs.channel }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,7 @@
-name: Publish erdjs (not main)
+name: Publish
 
 on:
   workflow_dispatch:
-    inputs:
-      channel:
-        type: choice
-        description: NPM channel
-        options: 
-        - alpha
-        - beta
-        - previous
 
 permissions:
   contents: write
@@ -29,12 +21,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_TAG=v$(node -p "require('./package.json').version")
-          gh release create --prerelease $RELEASE_TAG --target=$GITHUB_SHA --title="$RELEASE_TAG" --generate-notes
-
+          gh release create $RELEASE_TAG --target=$GITHUB_SHA --title="$RELEASE_TAG" --generate-notes
+      
       - run: npm ci
       - run: npm test
       
       - name: Publish to npmjs
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: npm publish --access=public --tag=${{ github.event.inputs.channel }}
+        run: npm publish --access=public

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,24 @@
 .PHONY: clean browser-tests
 
-browser-tests: out-browser-tests/erdjs-tests-unit.js out-browser-tests/erdjs-tests-unit-min.js out-browser-tests/erdjs-tests-localnet.js out-browser-tests/erdjs-tests-devnet.js out-browser-tests/erdjs-tests-testnet.js
+browser-tests: out-browser-tests/tests-unit.js out-browser-tests/tests-unit-min.js out-browser-tests/tests-localnet.js out-browser-tests/tests-devnet.js out-browser-tests/tests-testnet.js
 
-out-browser-tests/erdjs-tests-unit.js: out-tests
-	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/erdjs-tests-unit.js --standalone erdjs-tests -p esmify
+out-browser-tests/tests-unit.js: out-tests
+	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/tests-unit.js --standalone tests -p esmify
 
-out-browser-tests/erdjs-tests-unit-min.js: out-tests
-	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/erdjs-tests-unit-min.js --standalone erdjs-tests -p esmify -p tinyify
+out-browser-tests/tests-unit-min.js: out-tests
+	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/tests-unit-min.js --standalone tests -p esmify -p tinyify
 
-out-browser-tests/erdjs-tests-localnet.js: out-tests
-	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.local.net.spec.js') --require buffer/:buffer -o out-browser-tests/erdjs-tests-localnet.js --standalone erdjs-tests -p esmify
+out-browser-tests/tests-localnet.js: out-tests
+	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.local.net.spec.js') --require buffer/:buffer -o out-browser-tests/tests-localnet.js --standalone tests -p esmify
 
-out-browser-tests/erdjs-tests-devnet.js: out-tests
-	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.dev.net.spec.js') --require buffer/:buffer -o out-browser-tests/erdjs-tests-devnet.js --standalone erdjs-tests -p esmify
+out-browser-tests/tests-devnet.js: out-tests
+	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.dev.net.spec.js') --require buffer/:buffer -o out-browser-tests/tests-devnet.js --standalone tests -p esmify
 
-out-browser-tests/erdjs-tests-testnet.js: out-tests
-	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.test.net.spec.js') --require buffer/:buffer -o out-browser-tests/erdjs-tests-testnet.js --standalone erdjs-tests -p esmify
+out-browser-tests/tests-testnet.js: out-tests
+	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.test.net.spec.js') --require buffer/:buffer -o out-browser-tests/tests-testnet.js --standalone tests -p esmify
 
 out-tests:
 	npx tsc -p tsconfig.tests.json
-
-publish-erdjs-beta:
-	npm publish --tag=beta --access=public
-
-publish-erdjs:
-	npm publish --access=public
 
 clean:
 	rm -rf out-tests

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,9 @@
 .PHONY: clean browser-tests
 
-browser-tests: out-browser-tests/tests-unit.js out-browser-tests/tests-unit-min.js out-browser-tests/tests-localnet.js out-browser-tests/tests-devnet.js out-browser-tests/tests-testnet.js
+browser-tests: out-browser-tests/tests-unit.js out-browser-tests/tests-localnet.js out-browser-tests/tests-devnet.js out-browser-tests/tests-testnet.js
 
 out-browser-tests/tests-unit.js: out-tests
 	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/tests-unit.js --standalone tests -p esmify
-
-out-browser-tests/tests-unit-min.js: out-tests
-	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.net.spec.*') --require buffer/:buffer -o out-browser-tests/tests-unit-min.js --standalone tests -p esmify -p tinyify
 
 out-browser-tests/tests-localnet.js: out-tests
 	npx browserify $(shell find out-tests -type f -name '*.js' ! -name '*.spec.*') $(shell find out-tests -type f -name '*.local.net.spec.js') --require buffer/:buffer -o out-browser-tests/tests-localnet.js --standalone tests -p esmify

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ MultiversX SDK for JavaScript and TypeScript (written in TypeScript).
 
 ## Distribution
 
-[npm](https://www.npmjs.com/package/@multiversx/erdjs)
+[npm](https://www.npmjs.com/package/@multiversx/sdk-core)
 
 ## Installation
 
-`erdjs` is delivered via **npm** and it can be installed as follows:
+`sdk-core` is delivered via **npm** and it can be installed as follows:
 
 ```
-npm install @multiversx/erdjs
+npm install @multiversx/sdk-core
 ```
 
 ## Development
@@ -24,7 +24,7 @@ Feel free to skip this section if you are not a contributor.
 
 ### Prerequisites
 
-`browserify` is required to compile the browser-friendly versions of `erdjs`. It can be installed as follows:
+`browserify` is required to compile the browser-friendly versions of `sdk-core`. It can be installed as follows:
 
 ```
 npm install --global browserify
@@ -32,7 +32,7 @@ npm install --global browserify
 
 ### Building the library
 
-In order to compile `erdjs`, run the following:
+In order to compile the library, run the following:
 
 ```
 npm install

--- a/browser-tests/index.html
+++ b/browser-tests/index.html
@@ -3,7 +3,7 @@
 <head>
     <base href="../" />
     <meta charset="utf-8">
-    <title>Run erdjs Tests in the Browser</title>
+    <title>Run Tests in the Browser</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="/node_modules/mocha/mocha.css">
 </head>
@@ -14,27 +14,27 @@
             <div class="col-sm-12">
                 <ul id="TestChoices" class="list-group">
                     <li class="list-group-item">
-                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/erdjs-tests-unit.js')">
+                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/tests-unit.js')">
                             Unit tests
                         </button>
                     </li>
                     <li class="list-group-item">
-                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/erdjs-tests-unit-min.js')">
+                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/tests-unit-min.js')">
                             Unit tests (minified code)
                         </button>
                     </li>
                     <li class="list-group-item">
-                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/erdjs-tests-localnet.js')">
+                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/tests-localnet.js')">
                             Integration tests - local testnet
                         </button>
                     </li>
                     <li class="list-group-item">
-                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/erdjs-tests-devnet.js')">
+                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/tests-devnet.js')">
                             Integration tests - devnet
                         </button>
                     </li>
                     <li class="list-group-item">
-                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/erdjs-tests-testnet.js')">
+                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/tests-testnet.js')">
                             Integration tests - testnet
                         </button>
                     </li>

--- a/browser-tests/index.html
+++ b/browser-tests/index.html
@@ -19,11 +19,6 @@
                         </button>
                     </li>
                     <li class="list-group-item">
-                        <button class="btn btn-link" onclick="runTests('/out-browser-tests/tests-unit-min.js')">
-                            Unit tests (minified code)
-                        </button>
-                    </li>
-                    <li class="list-group-item">
                         <button class="btn btn-link" onclick="runTests('/out-browser-tests/tests-localnet.js')">
                             Integration tests - local testnet
                         </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@multiversx/erdjs",
-  "version": "11.1.3",
+  "name": "@multiversx/sdk-core",
+  "version": "11.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@multiversx/erdjs",
-      "version": "11.1.3",
+      "name": "@multiversx/sdk-core",
+      "version": "11.2.0",
       "license": "MIT",
       "dependencies": {
-        "@elrondnetwork/transaction-decoder": "1.0.0",
+        "@multiversx/sdk-transaction-decoder": "1.0.2",
         "bech32": "1.1.4",
         "bignumber.js": "9.0.1",
         "blake2b": "2.1.3",
@@ -19,8 +19,8 @@
         "protobufjs": "6.11.3"
       },
       "devDependencies": {
-        "@elrondnetwork/erdjs-network-providers": "1.0.0",
-        "@elrondnetwork/erdjs-walletcore": "2.0.0",
+        "@multiversx/sdk-network-providers": "1.2.1",
+        "@multiversx/sdk-wallet": "2.1.1",
         "@types/assert": "1.4.6",
         "@types/chai": "4.2.11",
         "@types/mocha": "9.1.0",
@@ -435,63 +435,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/@elrondnetwork/erdjs-network-providers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs-network-providers/-/erdjs-network-providers-1.0.0.tgz",
-      "integrity": "sha512-bmxA2GZTRTxSWtNhsdLQH20e9DQ+2lLb/q3EmhX05BlwEARgIz3Npi1IcvnFWN4rxucU8cgOiCifYhyW2QFXww==",
-      "dev": true,
-      "dependencies": {
-        "axios": "0.24.0",
-        "bech32": "1.1.4",
-        "bignumber.js": "9.0.1",
-        "buffer": "6.0.3",
-        "json-bigint": "1.0.0"
-      }
-    },
-    "node_modules/@elrondnetwork/erdjs-walletcore": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs-walletcore/-/erdjs-walletcore-2.0.0.tgz",
-      "integrity": "sha512-z92MyknT5NsE29/8EctfLNQ3yKrfpEPH2eHAlmv3H1JrBYZJp3DnOD7igMf9YQjLBYqjvI0+KgqIU8ABhEwMlA==",
-      "dev": true,
-      "dependencies": {
-        "@elrondnetwork/bls-wasm": "0.3.3",
-        "bech32": "1.1.4",
-        "bip39": "3.0.2",
-        "blake2b": "2.1.3",
-        "ed25519-hd-key": "1.1.2",
-        "keccak": "3.0.1",
-        "scryptsy": "2.1.0",
-        "tweetnacl": "1.0.3",
-        "uuid": "8.3.2"
-      }
-    },
-    "node_modules/@elrondnetwork/erdjs-walletcore/node_modules/keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@elrondnetwork/transaction-decoder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/transaction-decoder/-/transaction-decoder-1.0.0.tgz",
-      "integrity": "sha512-FFUDXffwDNwo4V6Co+S9ur3OPYyAEzwgen7gh7LtQrG7SNPELFHjl+YssABXI8v1+SWmqcrSxervMggAiDDXkg==",
-      "dependencies": {
-        "bech32": "^2.0.0"
-      }
-    },
-    "node_modules/@elrondnetwork/transaction-decoder/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -537,6 +480,64 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@multiversx/sdk-network-providers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.2.1.tgz",
+      "integrity": "sha512-hRCuoOf9Kh9qArsCPWUrVn45lTWzFloLK0F9f4vNh3WWw4SplfFE/G4TwN8+F35IFMArvTcPibXnRzMb5z48Jw==",
+      "dev": true,
+      "dependencies": {
+        "axios": "0.24.0",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "buffer": "6.0.3",
+        "json-bigint": "1.0.0"
+      }
+    },
+    "node_modules/@multiversx/sdk-transaction-decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-transaction-decoder/-/sdk-transaction-decoder-1.0.2.tgz",
+      "integrity": "sha512-j43QsKquu8N51WLmVlJ7dV2P3A1448R7/ktvl8r3i6wRMpfdtzDPNofTdHmMRT7DdQdvs4+RNgz8hVKL11Etsw==",
+      "dependencies": {
+        "bech32": "^2.0.0"
+      }
+    },
+    "node_modules/@multiversx/sdk-transaction-decoder/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/@multiversx/sdk-wallet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-2.1.1.tgz",
+      "integrity": "sha512-99wm+R8oLeNGuxnnbPiWVF1wHg81ev/IBU/2sAk/N7OX6ittY2+hRiSEN84Qv6186oJ/OgInEKtij4WwmdJuKw==",
+      "dev": true,
+      "dependencies": {
+        "@elrondnetwork/bls-wasm": "0.3.3",
+        "bech32": "1.1.4",
+        "bip39": "3.0.2",
+        "blake2b": "2.1.3",
+        "ed25519-hd-key": "1.1.2",
+        "ed2curve": "0.3.0",
+        "keccak": "3.0.1",
+        "scryptsy": "2.1.0",
+        "tweetnacl": "1.0.3",
+        "uuid": "8.3.2"
+      }
+    },
+    "node_modules/@multiversx/sdk-wallet/node_modules/keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1843,6 +1844,15 @@
         "bip39": "3.0.2",
         "create-hmac": "1.1.7",
         "tweetnacl": "1.0.3"
+      }
+    },
+    "node_modules/ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "1.x.x"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4730,63 +4740,6 @@
         "perf_hooks": "0.0.1"
       }
     },
-    "@elrondnetwork/erdjs-network-providers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs-network-providers/-/erdjs-network-providers-1.0.0.tgz",
-      "integrity": "sha512-bmxA2GZTRTxSWtNhsdLQH20e9DQ+2lLb/q3EmhX05BlwEARgIz3Npi1IcvnFWN4rxucU8cgOiCifYhyW2QFXww==",
-      "dev": true,
-      "requires": {
-        "axios": "0.24.0",
-        "bech32": "1.1.4",
-        "bignumber.js": "9.0.1",
-        "buffer": "6.0.3",
-        "json-bigint": "1.0.0"
-      }
-    },
-    "@elrondnetwork/erdjs-walletcore": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs-walletcore/-/erdjs-walletcore-2.0.0.tgz",
-      "integrity": "sha512-z92MyknT5NsE29/8EctfLNQ3yKrfpEPH2eHAlmv3H1JrBYZJp3DnOD7igMf9YQjLBYqjvI0+KgqIU8ABhEwMlA==",
-      "dev": true,
-      "requires": {
-        "@elrondnetwork/bls-wasm": "0.3.3",
-        "bech32": "1.1.4",
-        "bip39": "3.0.2",
-        "blake2b": "2.1.3",
-        "ed25519-hd-key": "1.1.2",
-        "keccak": "3.0.1",
-        "scryptsy": "2.1.0",
-        "tweetnacl": "1.0.3",
-        "uuid": "8.3.2"
-      },
-      "dependencies": {
-        "keccak": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-          "dev": true,
-          "requires": {
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
-      }
-    },
-    "@elrondnetwork/transaction-decoder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/transaction-decoder/-/transaction-decoder-1.0.0.tgz",
-      "integrity": "sha512-FFUDXffwDNwo4V6Co+S9ur3OPYyAEzwgen7gh7LtQrG7SNPELFHjl+YssABXI8v1+SWmqcrSxervMggAiDDXkg==",
-      "requires": {
-        "bech32": "^2.0.0"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-        }
-      }
-    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -4823,6 +4776,64 @@
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "@multiversx/sdk-network-providers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.2.1.tgz",
+      "integrity": "sha512-hRCuoOf9Kh9qArsCPWUrVn45lTWzFloLK0F9f4vNh3WWw4SplfFE/G4TwN8+F35IFMArvTcPibXnRzMb5z48Jw==",
+      "dev": true,
+      "requires": {
+        "axios": "0.24.0",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "buffer": "6.0.3",
+        "json-bigint": "1.0.0"
+      }
+    },
+    "@multiversx/sdk-transaction-decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-transaction-decoder/-/sdk-transaction-decoder-1.0.2.tgz",
+      "integrity": "sha512-j43QsKquu8N51WLmVlJ7dV2P3A1448R7/ktvl8r3i6wRMpfdtzDPNofTdHmMRT7DdQdvs4+RNgz8hVKL11Etsw==",
+      "requires": {
+        "bech32": "^2.0.0"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        }
+      }
+    },
+    "@multiversx/sdk-wallet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-2.1.1.tgz",
+      "integrity": "sha512-99wm+R8oLeNGuxnnbPiWVF1wHg81ev/IBU/2sAk/N7OX6ittY2+hRiSEN84Qv6186oJ/OgInEKtij4WwmdJuKw==",
+      "dev": true,
+      "requires": {
+        "@elrondnetwork/bls-wasm": "0.3.3",
+        "bech32": "1.1.4",
+        "bip39": "3.0.2",
+        "blake2b": "2.1.3",
+        "ed25519-hd-key": "1.1.2",
+        "ed2curve": "0.3.0",
+        "keccak": "3.0.1",
+        "scryptsy": "2.1.0",
+        "tweetnacl": "1.0.3",
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "keccak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "dev": true,
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        }
       }
     },
     "@protobufjs/aspromise": {
@@ -5937,6 +5948,15 @@
         "bip39": "3.0.2",
         "create-hmac": "1.1.7",
         "tweetnacl": "1.0.3"
+      }
+    },
+    "ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "1.x.x"
       }
     },
     "electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@multiversx/erdjs",
-  "version": "11.1.3",
+  "name": "@multiversx/sdk-core",
+  "version": "11.2.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",
@@ -14,7 +14,7 @@
     "tests-localnet": "mocha $(find . -name '*.local.net.spec.ts')",
     "tests-devnet": "mocha $(find . -name '*.dev.net.spec.ts')",
     "tests-testnet": "mocha $(find . -name '*.test.net.spec.ts')",
-    "compile-browser": "tsc -p tsconfig.json && browserify out/index.js -o out-browser/erdjs.js --standalone erdjs -p esmify",
+    "compile-browser": "tsc -p tsconfig.json && browserify out/index.js -o out-browser/sdk-core.js --standalone multiversxSdkCore -p esmify",
     "compile": "tsc -p tsconfig.json",
     "compile-proto": "npx pbjs -t static-module -w commonjs -o src/proto/compiled.js src/proto/transaction.proto && npx pbts -o src/proto/compiled.d.ts src/proto/compiled.js",
     "browser-tests": "make clean && make browser-tests && http-server --port=9876 -o browser-tests/index.html",
@@ -25,7 +25,7 @@
   "author": "MultiversX",
   "license": "MIT",
   "dependencies": {
-    "@elrondnetwork/transaction-decoder": "1.0.0",
+    "@multiversx/sdk-transaction-decoder": "1.0.2",
     "bech32": "1.1.4",
     "bignumber.js": "9.0.1",
     "blake2b": "2.1.3",
@@ -35,8 +35,8 @@
     "protobufjs": "6.11.3"
   },
   "devDependencies": {
-    "@elrondnetwork/erdjs-network-providers": "1.0.0",
-    "@elrondnetwork/erdjs-walletcore": "2.0.0",
+    "@multiversx/sdk-network-providers": "1.2.1",
+    "@multiversx/sdk-wallet": "2.1.1",
     "@types/assert": "1.4.6",
     "@types/chai": "4.2.11",
     "@types/mocha": "9.1.0",

--- a/src/_docs/errors.ts
+++ b/src/_docs/errors.ts
@@ -1,5 +1,5 @@
 /**
- * This module contains the errors raised by erdjs.
+ * This module contains the errors raised by the library.
  * @packageDocumentation
  * @module errors
  */

--- a/src/_docs/typesystem.ts
+++ b/src/_docs/typesystem.ts
@@ -1,5 +1,5 @@
 /**
- * This module defines erdjs' typesystem, that resembles the typesystem of `mx-sdk-rs`.
+ * This module defines a custom typesystem, that resembles the typesystem of `mx-sdk-rs`.
  * @packageDocumentation
  * @module typesystem
  */

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
 /**
- * The base class for `erdjs` exceptions (errors).
+ * The base class for exceptions (errors).
  */
 export class Err extends Error {
   inner: Error | undefined = undefined;
@@ -244,7 +244,7 @@ export class ErrTypeInferenceSystemRequiresRegularJavascriptObjects extends ErrT
     super(`
 argument at position ${index} seems to be a TypedValue. The automatic type inference system requires regular javascript objects as input.
 This error might occur when you pass a TypedValue to contract.methods.myFunction([...]). For passing TypedValues instead of regular javascript objects, and bypass the automatic type inference system, use contract.methodsExplicit.myFunction([...]) instead.
-Also see https://github.com/multiversx/mx-sdk-erdjs/pull/187.
+Also see https://github.com/multiversx/mx-sdk-js-core/pull/187.
 `);
   }
 }

--- a/src/gasEstimator.ts
+++ b/src/gasEstimator.ts
@@ -20,11 +20,11 @@ export const DefaultGasConfiguration: IGasConfiguration = {
     gasCostESDTNFTMultiTransfer: 200000
 };
 
-// Additional gas to account for eventual increases in gas requirements (thus avoid fast-breaking changes in clients of erdjs).
+// Additional gas to account for eventual increases in gas requirements (thus avoid fast-breaking changes in clients of the library).
 const ADDITIONAL_GAS_FOR_ESDT_TRANSFER = 100000;
 
 // Additional gas to account for extra blockchain operations (e.g. data movement (between accounts) for NFTs), 
-// and for eventual increases in gas requirements (thus avoid fast-breaking changes in clients of erdjs).
+// and for eventual increases in gas requirements (thus avoid fast-breaking changes in clients of the library).
 const ADDITIONAL_GAS_FOR_ESDT_NFT_TRANSFER = 800000;
 
 export class GasEstimator {

--- a/src/smartcontracts/codec/numerical.ts
+++ b/src/smartcontracts/codec/numerical.ts
@@ -84,7 +84,7 @@ export class NumericalBinaryCodec {
         }
 
         // Negative:
-        // Also see: https://github.com/ElrondNetwork/big-int-util/blob/master/twos-complement/bigint2twos.go
+        // Also see: https://github.com/multiversx/mx-components-big-int/blob/master/twos-complement/bigint2twos.go
         let valuePlusOne = primitive.value.plus(new BigNumber(1));
         let buffer = bigIntToBuffer(valuePlusOne);
         flipBufferBitsInPlace(buffer);

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -1,30 +1,30 @@
-import { ContractController } from "../testutils/contractController";
-import { SmartContract } from "./smartContract";
-import { BigUIntValue, OptionalValue, OptionValue, TokenIdentifierValue, U32Value } from "./typesystem";
+import { ContractQueryResponse } from "@multiversx/sdk-network-providers";
+import BigNumber from "bignumber.js";
+import { assert } from "chai";
+import { Address } from "../address";
 import {
     loadAbiRegistry,
     loadTestWallets,
     MockProvider,
     setupUnitTestWatcherTimeouts,
-    TestWallet,
+    TestWallet
 } from "../testutils";
-import { SmartContractAbi } from "./abi";
-import { Address } from "../address";
-import { assert } from "chai";
-import { Interaction } from "./interaction";
-import { ContractFunction } from "./function";
-import { ReturnCode } from "./returnCode";
-import BigNumber from "bignumber.js";
-import { BytesValue } from "./typesystem/bytes";
+import { ContractController } from "../testutils/contractController";
 import { TokenPayment } from "../tokenPayment";
-import { ContractQueryResponse } from "@elrondnetwork/erdjs-network-providers";
+import { SmartContractAbi } from "./abi";
+import { ContractFunction } from "./function";
+import { Interaction } from "./interaction";
+import { ReturnCode } from "./returnCode";
+import { SmartContract } from "./smartContract";
+import { BigUIntValue, OptionalValue, OptionValue, TokenIdentifierValue, U32Value } from "./typesystem";
+import { BytesValue } from "./typesystem/bytes";
 
-describe("test smart contract interactor", function() {
+describe("test smart contract interactor", function () {
     let dummyAddress = new Address("erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3");
     let provider = new MockProvider();
     let alice: TestWallet;
 
-    before(async function() {
+    before(async function () {
         ({ alice } = await loadTestWallets());
     });
 
@@ -49,7 +49,7 @@ describe("test smart contract interactor", function() {
         let contract = new SmartContract({ address: dummyAddress });
         let dummyFunction = new ContractFunction("dummy");
         let alice = new Address("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
-        
+
         const TokenFoo = (amount: BigNumber.Value) => TokenPayment.fungibleFromAmount("FOO-6ce17b", amount, 0);
         const TokenBar = (amount: BigNumber.Value) => TokenPayment.fungibleFromAmount("BAR-5bc08f", amount, 3);
         const LKMEX = (nonce: number, amount: BigNumber.Value) => TokenPayment.metaEsdtFromAmount("LKMEX-aab910", nonce, amount, 18);
@@ -94,7 +94,7 @@ describe("test smart contract interactor", function() {
         transaction = new Interaction(contract, dummyFunction, [])
             .withMultiESDTNFTTransfer([Strămoși(1), Strămoși(42)], alice)
             .buildTransaction();
-        
+
         assert.equal(transaction.getData().toString(), `MultiESDTNFTTransfer@${hexContractAddress}@02@${hexStrămoși}@01@01@${hexStrămoși}@2a@01@${hexDummyFunction}`);
     });
 
@@ -160,7 +160,7 @@ describe("test smart contract interactor", function() {
         assert.isTrue(bundle.returnCode.equals(ReturnCode.Ok));
     });
 
-    it("should interact with 'counter'", async function() {
+    it("should interact with 'counter'", async function () {
         setupUnitTestWatcherTimeouts();
 
         let abiRegistry = await loadAbiRegistry("src/testdata/counter.abi.json");
@@ -207,7 +207,7 @@ describe("test smart contract interactor", function() {
         assert.deepEqual(valueAfterDecrement!.valueOf(), new BigNumber(5));
     });
 
-    it("should interact with 'lottery-esdt'", async function() {
+    it("should interact with 'lottery-esdt'", async function () {
         setupUnitTestWatcherTimeouts();
 
         let abiRegistry = await loadAbiRegistry("src/testdata/lottery-esdt.abi.json");
@@ -256,7 +256,7 @@ describe("test smart contract interactor", function() {
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@01");
         let { bundle: { returnCode: statusReturnCode, values: statusReturnValues, firstValue: statusFirstValue } } = await controller.execute(statusInteraction, statusTransaction);
 
-        assert.equal(statusTransaction.getData().toString(),"status@6c75636b79");
+        assert.equal(statusTransaction.getData().toString(), "status@6c75636b79");
         assert.isTrue(statusReturnCode.equals(ReturnCode.Ok));
         assert.lengthOf(statusReturnValues, 1);
         assert.deepEqual(statusFirstValue!.valueOf(), { name: "Running", fields: [] });
@@ -265,7 +265,7 @@ describe("test smart contract interactor", function() {
         let getLotteryInfoTransaction = getLotteryInfoInteraction.withNonce(15).buildTransaction();
         await alice.signer.sign(getLotteryInfoTransaction);
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@0000000b6c75636b792d746f6b656e000000010100000000000000005fc2b9dbffffffff00000001640000000a140ec80fa7ee88000000");
-        let { bundle: { returnCode: infoReturnCode, values: infoReturnValues, firstValue: infoFirstValue} } = await controller.execute(getLotteryInfoInteraction, getLotteryInfoTransaction);
+        let { bundle: { returnCode: infoReturnCode, values: infoReturnValues, firstValue: infoFirstValue } } = await controller.execute(getLotteryInfoInteraction, getLotteryInfoTransaction);
 
         assert.equal(getLotteryInfoTransaction.getData().toString(), "getLotteryInfo@6c75636b79");
         assert.isTrue(infoReturnCode.equals(ReturnCode.Ok));

--- a/src/smartcontracts/resultsParser.spec.ts
+++ b/src/smartcontracts/resultsParser.spec.ts
@@ -1,4 +1,4 @@
-import { ContractQueryResponse, ContractResultItem, ContractResults, TransactionEvent, TransactionEventTopic, TransactionLogs, TransactionOnNetwork } from "@elrondnetwork/erdjs-network-providers";
+import { ContractQueryResponse, ContractResultItem, ContractResults, TransactionEvent, TransactionEventTopic, TransactionLogs, TransactionOnNetwork } from "@multiversx/sdk-network-providers";
 import { assert } from "chai";
 import * as fs from "fs";
 import path from "path";

--- a/src/smartcontracts/resultsParser.ts
+++ b/src/smartcontracts/resultsParser.ts
@@ -1,4 +1,4 @@
-import { TransactionDecoder, TransactionMetadata } from "@elrondnetwork/transaction-decoder";
+import { TransactionDecoder, TransactionMetadata } from "@multiversx/sdk-transaction-decoder/lib/src/transaction.decoder";
 import { Address } from "../address";
 import { ErrCannotParseContractResults } from "../errors";
 import { IAddress } from "../interface";
@@ -148,8 +148,7 @@ export class ResultsParser {
             sender: transaction.sender.bech32(),
             receiver: transaction.receiver.bech32(),
             data: transaction.data.toString("base64"),
-            value: transaction.value.toString(),
-            type: transaction.type
+            value: transaction.value.toString()
         });
     }
 

--- a/src/smartcontracts/smartContract.spec.ts
+++ b/src/smartcontracts/smartContract.spec.ts
@@ -1,13 +1,13 @@
+import { TransactionStatus } from "@multiversx/sdk-network-providers";
 import { assert } from "chai";
 import { Address } from "../address";
-import { Code } from "./code";
-import { SmartContract } from "./smartContract";
 import { loadTestWallets, MarkCompleted, MockProvider, setupUnitTestWatcherTimeouts, TestWallet, Wait } from "../testutils";
+import { TransactionWatcher } from "../transactionWatcher";
+import { Code } from "./code";
 import { ContractFunction } from "./function";
+import { SmartContract } from "./smartContract";
 import { U32Value } from "./typesystem";
 import { BytesValue } from "./typesystem/bytes";
-import { TransactionWatcher } from "../transactionWatcher";
-import { TransactionStatus } from "@elrondnetwork/erdjs-network-providers";
 
 
 describe("test contract", () => {
@@ -72,7 +72,7 @@ describe("test contract", () => {
     it("should call", async () => {
         setupUnitTestWatcherTimeouts();
         let watcher = new TransactionWatcher(provider);
-        
+
         let contract = new SmartContract({ address: new Address("erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3") });
 
         provider.mockUpdateAccount(alice.address, account => {

--- a/src/smartcontracts/typesystem/types.spec.ts
+++ b/src/smartcontracts/typesystem/types.spec.ts
@@ -1,14 +1,14 @@
-import * as errors from "../../errors";
-import { assert } from "chai";
-import { I64Type, NumericalValue, U16Type, U32Type, U32Value, U8Type } from "./numerical";
-import { PrimitiveType, Type, NullType } from "./types";
-import { BooleanType } from "./boolean";
-import { AddressType } from "./address";
-import { OptionType } from "./generic";
-import { TypeExpressionParser } from "./typeExpressionParser";
 import BigNumber from "bignumber.js";
-import { BytesType, BytesValue} from "./bytes";
+import { assert } from "chai";
+import * as errors from "../../errors";
+import { AddressType } from "./address";
+import { BooleanType } from "./boolean";
+import { BytesType, BytesValue } from "./bytes";
+import { OptionType } from "./generic";
+import { I64Type, NumericalValue, U16Type, U32Type, U32Value } from "./numerical";
 import { StringType } from "./string";
+import { TypeExpressionParser } from "./typeExpressionParser";
+import { NullType, PrimitiveType, Type } from "./types";
 
 describe("test types", () => {
     let parser = new TypeExpressionParser();
@@ -52,11 +52,11 @@ describe("test types", () => {
     });
 
     it("should get fully qualified name", () => {
-        assert.equal(new Type("foo").getFullyQualifiedName(), "erdjs:types:foo");
-        assert.equal(new U32Type().getFullyQualifiedName(), "erdjs:types:u32");
-        assert.equal(parser.parse("MultiResultVec<u32>").getFullyQualifiedName(), "erdjs:types:MultiResultVec<erdjs:types:u32>");
-        assert.equal(parser.parse("utf-8 string").getFullyQualifiedName(), "erdjs:types:utf-8 string");
-        assert.equal(parser.parse("Option<u32>").getFullyQualifiedName(), "erdjs:types:Option<erdjs:types:u32>");
+        assert.equal(new Type("foo").getFullyQualifiedName(), "multiversx:types:foo");
+        assert.equal(new U32Type().getFullyQualifiedName(), "multiversx:types:u32");
+        assert.equal(parser.parse("MultiResultVec<u32>").getFullyQualifiedName(), "multiversx:types:MultiResultVec<multiversx:types:u32>");
+        assert.equal(parser.parse("utf-8 string").getFullyQualifiedName(), "multiversx:types:utf-8 string");
+        assert.equal(parser.parse("Option<u32>").getFullyQualifiedName(), "multiversx:types:Option<multiversx:types:u32>");
     });
 
     it("types and values should have correct JavaScript class hierarchy", () => {

--- a/src/smartcontracts/typesystem/types.ts
+++ b/src/smartcontracts/typesystem/types.ts
@@ -35,14 +35,14 @@ export class Type {
     }
 
     /**
-     * Gets the fully qualified name of the type, to allow for better (efficient and non-ambiguous) type comparison within erdjs' typesystem.
+     * Gets the fully qualified name of the type, to allow for better (efficient and non-ambiguous) type comparison within the custom typesystem.
      */
     getFullyQualifiedName(): string {
         let joinedTypeParameters = this.getTypeParameters().map(type => type.getFullyQualifiedName()).join(", ");
 
         return this.isGenericType() ?
-            `erdjs:types:${this.getName()}<${joinedTypeParameters}>` :
-            `erdjs:types:${this.getName()}`;
+            `multiversx:types:${this.getName()}<${joinedTypeParameters}>` :
+            `multiversx:types:${this.getName()}`;
     }
 
     hasExactClass(className: string): boolean {
@@ -159,7 +159,7 @@ export class Type {
     }
 
     /**
-     * A special marker for types within erdjs' typesystem.
+     * A special marker for types within the custom typesystem.
      */
     belongsToTypesystem() { }
 }
@@ -276,7 +276,7 @@ export abstract class TypedValue {
     }
 
     /**
-     * A special marker for values within erdjs' typesystem.
+     * A special marker for values within the custom typesystem.
      */
     belongsToTypesystem() { }
 }

--- a/src/testutils/mockProvider.ts
+++ b/src/testutils/mockProvider.ts
@@ -1,12 +1,12 @@
-import { IAddress } from "../interface";
-import { Transaction, TransactionHash } from "../transaction";
+import { AccountOnNetwork, ContractResultItem, ContractResults, TransactionOnNetwork, TransactionStatus } from "@multiversx/sdk-network-providers";
 import { Address } from "../address";
 import { AsyncTimer } from "../asyncTimer";
 import * as errors from "../errors";
-import { Query } from "../smartcontracts/query";
-import { IAccountOnNetwork, IContractQueryResponse, INetworkConfig, ITransactionOnNetwork, ITransactionStatus } from "../interfaceOfNetwork";
 import { ErrMock } from "../errors";
-import { AccountOnNetwork, ContractResultItem, ContractResults, TransactionOnNetwork, TransactionStatus } from "@elrondnetwork/erdjs-network-providers";
+import { IAddress } from "../interface";
+import { IAccountOnNetwork, IContractQueryResponse, INetworkConfig, ITransactionOnNetwork, ITransactionStatus } from "../interfaceOfNetwork";
+import { Query } from "../smartcontracts/query";
+import { Transaction, TransactionHash } from "../transaction";
 import { createAccountBalance } from "./utils";
 
 export class MockProvider {

--- a/src/testutils/networkProviders.ts
+++ b/src/testutils/networkProviders.ts
@@ -1,4 +1,4 @@
-import { ProxyNetworkProvider } from "@elrondnetwork/erdjs-network-providers";
+import { ProxyNetworkProvider } from "@multiversx/sdk-network-providers";
 import { IAddress } from "../interface";
 import { IAccountOnNetwork, IContractQueryResponse, INetworkConfig, ITransactionOnNetwork, ITransactionStatus } from "../interfaceOfNetwork";
 import { Query } from "../smartcontracts/query";

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -1,12 +1,12 @@
+import { UserSecretKey, UserSigner } from "@multiversx/sdk-wallet";
 import axios from "axios";
 import * as fs from "fs";
 import * as path from "path";
 import { Account } from "../account";
 import { Address } from "../address";
 import { IAddress } from "../interface";
-import { isOnBrowserTests } from "./utils";
-import { UserSecretKey, UserSigner } from "@elrondnetwork/erdjs-walletcore"
 import { IAccountOnNetwork } from "../interfaceOfNetwork";
+import { isOnBrowserTests } from "./utils";
 
 interface IAccountFetcher {
     getAccount(address: IAddress): Promise<IAccountOnNetwork>;
@@ -62,7 +62,7 @@ async function readTestWalletFileContents(name: string): Promise<string> {
 }
 
 async function downloadTextFile(url: string) {
-    let response = await axios.get(url, { responseType: "text", transformResponse: []});
+    let response = await axios.get(url, { responseType: "text", transformResponse: [] });
     let text = response.data.toString();
     return text;
 }

--- a/src/tokenPayment.spec.ts
+++ b/src/tokenPayment.spec.ts
@@ -49,12 +49,12 @@ describe("test token payment", () => {
     });
 
     it("should work with NFTs", () => {
-        let identifier = "ERDJS-38f249";
+        let identifier = "TEST-38f249";
         let nonce = 1;
 
         let tokenPayment = TokenPayment.nonFungible(identifier, nonce)
         assert.equal(tokenPayment.tokenIdentifier, identifier);
         assert.equal(tokenPayment.nonce, nonce);
-        assert.equal(tokenPayment.toPrettyString(), "1 ERDJS-38f249");
+        assert.equal(tokenPayment.toPrettyString(), "1 TEST-38f249");
     });
 });

--- a/src/transactionWatcher.spec.ts
+++ b/src/transactionWatcher.spec.ts
@@ -1,8 +1,8 @@
+import { TransactionOnNetwork, TransactionStatus } from "@multiversx/sdk-network-providers";
 import { assert } from "chai";
-import { TransactionWatcher } from "./transactionWatcher";
+import { MarkCompleted, MockProvider, Wait } from "./testutils";
 import { TransactionHash } from "./transaction";
-import { MockProvider, MarkCompleted, Wait } from "./testutils";
-import { TransactionOnNetwork, TransactionStatus } from "@elrondnetwork/erdjs-network-providers";
+import { TransactionWatcher } from "./transactionWatcher";
 
 
 describe("test transactionWatcher", () => {


### PR DESCRIPTION
 - The name of the custom typesystem changed, as well: `erdjs -> multiversx`. This should not be (is not) a breaking change.
 - Dependencies have been updated (to refer the new organization).