### PR TITLE
Temporary, non-breaking workaround: WARN if sender isn't set.

### DIFF
--- a/src/address.ts
+++ b/src/address.ts
@@ -1,5 +1,6 @@
 import * as bech32 from "bech32";
 import * as errors from "./errors";
+import { IAddress } from "./interface";
 
 /**
  * The human-readable-part of the bech32 addresses.
@@ -194,5 +195,18 @@ export class Address {
 
     isContractAddress(): boolean {
         return this.hex().startsWith(SMART_CONTRACT_HEX_PUBKEY_PREFIX);
+    }
+}
+
+/**
+ * Temporary workaround to check if an address is set or not (especially for warning developers when 'transaction.sender' isn't set).
+ * Added in v11, to reduce mistakes when creating transactions. It's just a WARN, to avoid breaking changes for now.
+ * This function will be removed in v12, when the 'sender' field will be mandatory (on all components).
+ * 
+ * For internal use only.
+ */
+export function warnIfAddressIsNotSetOrZero(address: IAddress | undefined, message: string) {
+    if (!address || address.bech32() == "" || address.bech32() == Address.Zero().bech32()) {
+        console.warn(message);
     }
 }

--- a/src/smartcontracts/interaction.local.net.spec.ts
+++ b/src/smartcontracts/interaction.local.net.spec.ts
@@ -1,18 +1,18 @@
-import { ContractController } from "../testutils/contractController";
-import { SmartContract } from "./smartContract";
-import { prepareDeployment, loadAbiRegistry, loadTestWallets, TestWallet } from "../testutils";
-import { SmartContractAbi } from "./abi";
+import BigNumber from "bignumber.js";
 import { assert } from "chai";
+import { loadAbiRegistry, loadTestWallets, prepareDeployment, TestWallet } from "../testutils";
+import { ContractController } from "../testutils/contractController";
+import { createLocalnetProvider } from "../testutils/networkProviders";
+import { SmartContractAbi } from "./abi";
 import { Interaction } from "./interaction";
 import { ReturnCode } from "./returnCode";
-import BigNumber from "bignumber.js";
-import { createLocalnetProvider } from "../testutils/networkProviders";
+import { SmartContract } from "./smartContract";
 
 
 describe("test smart contract interactor", function () {
     let provider = createLocalnetProvider();
     let alice: TestWallet;
-    
+
     before(async function () {
         ({ alice } = await loadTestWallets());
     });
@@ -42,6 +42,7 @@ describe("test smart contract interactor", function () {
         assert.isTrue(returnCode.isSuccess());
 
         let interaction = <Interaction>contract.methods.getUltimateAnswer()
+            .withCaller(alice.address)
             .withGasLimit(3000000)
             .withChainID(network.ChainID);
 
@@ -91,9 +92,11 @@ describe("test smart contract interactor", function () {
 
         let getInteraction = <Interaction>contract.methods.get();
         let incrementInteraction = (<Interaction>contract.methods.increment())
+            .withCaller(alice.account.address)
             .withGasLimit(3000000)
             .withChainID(network.ChainID);
         let decrementInteraction = (<Interaction>contract.methods.decrement())
+            .withCaller(alice.account.address)
             .withGasLimit(3000000)
             .withChainID(network.ChainID);
 
@@ -152,16 +155,19 @@ describe("test smart contract interactor", function () {
             null,
             null
         ])
-        .withGasLimit(30000000)
-        .withChainID(network.ChainID);
+            .withCaller(alice.account.address)
+            .withGasLimit(30000000)
+            .withChainID(network.ChainID);
 
         let lotteryStatusInteraction = <Interaction>contract.methods.status(["lucky"])
-        .withGasLimit(5000000)
-        .withChainID(network.ChainID);
+            .withCaller(alice.account.address)
+            .withGasLimit(5000000)
+            .withChainID(network.ChainID);
 
         let getLotteryInfoInteraction = <Interaction>contract.methods.getLotteryInfo(["lucky"])
-        .withGasLimit(5000000)
-        .withChainID(network.ChainID);
+            .withCaller(alice.account.address)
+            .withGasLimit(5000000)
+            .withChainID(network.ChainID);
 
         // start()
         let startTransaction = startInteraction.useThenIncrementNonceOf(alice.account).buildTransaction();

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -35,6 +35,7 @@ describe("test smart contract interactor", function () {
 
         let transaction = interaction
             .withNonce(7)
+            .withCaller(alice.address)
             .withValue(TokenPayment.egldFromAmount(1))
             .withGasLimit(20000000)
             .buildTransaction();
@@ -64,6 +65,7 @@ describe("test smart contract interactor", function () {
 
         // ESDT, single
         let transaction = new Interaction(contract, dummyFunction, [])
+            .withCaller(alice)
             .withSingleESDTTransfer(TokenFoo(10))
             .buildTransaction();
 
@@ -71,6 +73,7 @@ describe("test smart contract interactor", function () {
 
         // Meta ESDT (special SFT), single
         transaction = new Interaction(contract, dummyFunction, [])
+            .withCaller(alice)
             .withSingleESDTNFTTransfer(LKMEX(123456, 123.456), alice)
             .buildTransaction();
 
@@ -78,6 +81,7 @@ describe("test smart contract interactor", function () {
 
         // NFT, single
         transaction = new Interaction(contract, dummyFunction, [])
+            .withCaller(alice)
             .withSingleESDTNFTTransfer(Strămoși(1), alice)
             .buildTransaction();
 
@@ -85,6 +89,7 @@ describe("test smart contract interactor", function () {
 
         // ESDT, multiple
         transaction = new Interaction(contract, dummyFunction, [])
+            .withCaller(alice)
             .withMultiESDTNFTTransfer([TokenFoo(3), TokenBar(3.14)], alice)
             .buildTransaction();
 
@@ -92,6 +97,7 @@ describe("test smart contract interactor", function () {
 
         // NFT, multiple
         transaction = new Interaction(contract, dummyFunction, [])
+            .withCaller(alice)
             .withMultiESDTNFTTransfer([Strămoși(1), Strămoși(42)], alice)
             .buildTransaction();
 
@@ -108,6 +114,7 @@ describe("test smart contract interactor", function () {
 
         let interaction = <Interaction>contract.methods
             .getUltimateAnswer()
+            .withCaller(alice.address)
             .withGasLimit(543210)
             .withChainID("T");
 
@@ -183,7 +190,7 @@ describe("test smart contract interactor", function () {
 
         assert.deepEqual(counterValue!.valueOf(), new BigNumber(7));
 
-        let incrementTransaction = incrementInteraction.withNonce(14).buildTransaction();
+        let incrementTransaction = incrementInteraction.withNonce(14).withCaller(alice.account.address).buildTransaction();
         await alice.signer.sign(incrementTransaction);
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@08");
         let { bundle: { firstValue: valueAfterIncrement } } = await controller.execute(incrementInteraction, incrementTransaction);
@@ -191,16 +198,16 @@ describe("test smart contract interactor", function () {
 
         // Decrement three times (simulate three parallel broadcasts). Wait for execution of the latter (third transaction). Return fake "5".
         // Decrement #1
-        let decrementTransaction = decrementInteraction.withNonce(15).buildTransaction();
+        let decrementTransaction = decrementInteraction.withNonce(15).withCaller(alice.account.address).buildTransaction();
         await alice.signer.sign(decrementTransaction);
         await provider.sendTransaction(decrementTransaction);
         // Decrement #2
-        decrementTransaction = decrementInteraction.withNonce(16).buildTransaction();
+        decrementTransaction = decrementInteraction.withNonce(16).withCaller(alice.account.address).buildTransaction();
         await alice.signer.sign(decrementTransaction);
         await provider.sendTransaction(decrementTransaction);
         // Decrement #3
 
-        decrementTransaction = decrementInteraction.withNonce(17).buildTransaction();
+        decrementTransaction = decrementInteraction.withNonce(17).withCaller(alice.account.address).buildTransaction();
         await alice.signer.sign(decrementTransaction);
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@05");
         let { bundle: { firstValue: valueAfterDecrement } } = await controller.execute(decrementInteraction, decrementTransaction);
@@ -241,7 +248,7 @@ describe("test smart contract interactor", function () {
         );
 
         // start()
-        let startTransaction = startInteraction.withNonce(14).buildTransaction();
+        let startTransaction = startInteraction.withNonce(14).withCaller(alice.account.address).buildTransaction();
         await alice.signer.sign(startTransaction);
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b");
         let { bundle: { returnCode: startReturnCode, values: startReturnValues } } = await controller.execute(startInteraction, startTransaction);
@@ -251,7 +258,7 @@ describe("test smart contract interactor", function () {
         assert.lengthOf(startReturnValues, 0);
 
         // status() (this is a view function, but for the sake of the test, we'll execute it)
-        let statusTransaction = statusInteraction.withNonce(15).buildTransaction();
+        let statusTransaction = statusInteraction.withNonce(15).withCaller(alice.account.address).buildTransaction();
         await alice.signer.sign(statusTransaction);
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@01");
         let { bundle: { returnCode: statusReturnCode, values: statusReturnValues, firstValue: statusFirstValue } } = await controller.execute(statusInteraction, statusTransaction);
@@ -262,7 +269,7 @@ describe("test smart contract interactor", function () {
         assert.deepEqual(statusFirstValue!.valueOf(), { name: "Running", fields: [] });
 
         // lotteryInfo() (this is a view function, but for the sake of the test, we'll execute it)
-        let getLotteryInfoTransaction = getLotteryInfoInteraction.withNonce(15).buildTransaction();
+        let getLotteryInfoTransaction = getLotteryInfoInteraction.withNonce(15).withCaller(alice.account.address).buildTransaction();
         await alice.signer.sign(getLotteryInfoTransaction);
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@0000000b6c75636b792d746f6b656e000000010100000000000000005fc2b9dbffffffff00000001640000000a140ec80fa7ee88000000");
         let { bundle: { returnCode: infoReturnCode, values: infoReturnValues, firstValue: infoFirstValue } } = await controller.execute(getLotteryInfoInteraction, getLotteryInfoTransaction);

--- a/src/smartcontracts/interface.ts
+++ b/src/smartcontracts/interface.ts
@@ -29,6 +29,8 @@ export interface ISmartContract {
 }
 
 export interface DeployArguments {
+    // TODO: in v12, make "owner" required.
+    owner?: IAddress;
     code: ICode;
     codeMetadata?: ICodeMetadata;
     initArguments?: TypedValue[];
@@ -39,6 +41,8 @@ export interface DeployArguments {
 }
 
 export interface UpgradeArguments {
+    // TODO: in v12, make "owner" required.
+    owner?: IAddress;
     code: ICode;
     codeMetadata?: ICodeMetadata;
     initArguments?: TypedValue[];
@@ -49,6 +53,8 @@ export interface UpgradeArguments {
 }
 
 export interface CallArguments {
+    // TODO: in v12, make "caller" required.
+    caller?: IAddress;
     func: IContractFunction;
     args?: TypedValue[];
     value?: ITransactionValue;

--- a/src/smartcontracts/smartContract.local.net.spec.ts
+++ b/src/smartcontracts/smartContract.local.net.spec.ts
@@ -1,15 +1,15 @@
-import { SmartContract } from "./smartContract";
-import { TransactionWatcher } from "../transactionWatcher";
-import { ContractFunction } from "./function";
-import { loadTestWallets, TestWallet } from "../testutils/wallets";
-import { prepareDeployment } from "../testutils";
-import { Logger } from "../logger";
 import { assert } from "chai";
-import { AddressValue, BigUIntValue, OptionalValue, OptionValue, TokenIdentifierValue, U32Value } from "./typesystem";
-import { decodeUnsignedNumber } from "./codec";
-import { BytesValue } from "./typesystem/bytes";
-import { ResultsParser } from "./resultsParser";
+import { Logger } from "../logger";
+import { prepareDeployment } from "../testutils";
 import { createLocalnetProvider } from "../testutils/networkProviders";
+import { loadTestWallets, TestWallet } from "../testutils/wallets";
+import { TransactionWatcher } from "../transactionWatcher";
+import { decodeUnsignedNumber } from "./codec";
+import { ContractFunction } from "./function";
+import { ResultsParser } from "./resultsParser";
+import { SmartContract } from "./smartContract";
+import { AddressValue, BigUIntValue, OptionalValue, OptionValue, TokenIdentifierValue, U32Value } from "./typesystem";
+import { BytesValue } from "./typesystem/bytes";
 
 describe("test on local testnet", function () {
     let provider = createLocalnetProvider();
@@ -32,7 +32,7 @@ describe("test on local testnet", function () {
 
         // Deploy
         let contract = new SmartContract({});
-        
+
         let transactionDeploy = await prepareDeployment({
             contract: contract,
             deployer: alice,
@@ -44,6 +44,7 @@ describe("test on local testnet", function () {
 
         // ++
         let transactionIncrement = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("increment"),
             gasLimit: 3000000,
             chainID: network.ChainID
@@ -56,12 +57,14 @@ describe("test on local testnet", function () {
 
         // Now, let's build a few transactions, to be simulated
         let simulateOne = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("increment"),
             gasLimit: 100000,
             chainID: network.ChainID
         });
 
         let simulateTwo = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("foobar"),
             gasLimit: 500000,
             chainID: network.ChainID
@@ -115,6 +118,7 @@ describe("test on local testnet", function () {
 
         // ++
         let transactionIncrementFirst = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("increment"),
             gasLimit: 2000000,
             chainID: network.ChainID
@@ -127,6 +131,7 @@ describe("test on local testnet", function () {
 
         // ++
         let transactionIncrementSecond = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("increment"),
             gasLimit: 2000000,
             chainID: network.ChainID
@@ -175,6 +180,7 @@ describe("test on local testnet", function () {
 
         // Minting
         let transactionMintBob = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("transferToken"),
             gasLimit: 9000000,
             args: [new AddressValue(bob.address), new U32Value(1000)],
@@ -182,6 +188,7 @@ describe("test on local testnet", function () {
         });
 
         let transactionMintCarol = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("transferToken"),
             gasLimit: 9000000,
             args: [new AddressValue(carol.address), new U32Value(1500)],
@@ -247,7 +254,7 @@ describe("test on local testnet", function () {
 
         // Deploy
         let contract = new SmartContract({});
-        
+
         let transactionDeploy = await prepareDeployment({
             contract: contract,
             deployer: alice,
@@ -259,6 +266,7 @@ describe("test on local testnet", function () {
 
         // Start
         let transactionStart = contract.call({
+            caller: alice.account.address,
             func: new ContractFunction("start"),
             gasLimit: 10000000,
             args: [

--- a/src/smartcontracts/smartContract.spec.ts
+++ b/src/smartcontracts/smartContract.spec.ts
@@ -35,6 +35,7 @@ describe("test contract", () => {
 
         let contract = new SmartContract({});
         let deployTransaction = contract.deploy({
+            owner: alice.address,
             code: Code.fromBuffer(Buffer.from([1, 2, 3, 4])),
             gasLimit: 1000000,
             chainID: chainID
@@ -80,6 +81,7 @@ describe("test contract", () => {
         });
 
         let callTransactionOne = contract.call({
+            caller: alice.address,
             func: new ContractFunction("helloEarth"),
             args: [new U32Value(5), BytesValue.fromHex("0123")],
             gasLimit: 150000,
@@ -87,6 +89,7 @@ describe("test contract", () => {
         });
 
         let callTransactionTwo = contract.call({
+            caller: alice.address,
             func: new ContractFunction("helloMars"),
             args: [new U32Value(5), BytesValue.fromHex("0123")],
             gasLimit: 1500000,

--- a/src/smartcontracts/smartContractResults.local.net.spec.ts
+++ b/src/smartcontracts/smartContractResults.local.net.spec.ts
@@ -1,10 +1,10 @@
-import { loadTestWallets, prepareDeployment, TestWallet } from "../testutils";
-import { TransactionWatcher } from "../transactionWatcher";
 import { assert } from "chai";
-import { SmartContract } from "./smartContract";
+import { loadTestWallets, prepareDeployment, TestWallet } from "../testutils";
+import { createLocalnetProvider } from "../testutils/networkProviders";
+import { TransactionWatcher } from "../transactionWatcher";
 import { ContractFunction } from "./function";
 import { ResultsParser } from "./resultsParser";
-import { createLocalnetProvider } from "../testutils/networkProviders";
+import { SmartContract } from "./smartContract";
 
 describe("fetch transactions from local testnet", function () {
     let provider = createLocalnetProvider();
@@ -39,6 +39,7 @@ describe("fetch transactions from local testnet", function () {
 
         // ++
         let transactionIncrement = contract.call({
+            caller: alice.address,
             func: new ContractFunction("increment"),
             gasLimit: 3000000,
             chainID: network.ChainID

--- a/src/testutils/utils.ts
+++ b/src/testutils/utils.ts
@@ -1,14 +1,14 @@
-import { PathLike } from "fs";
+import axios, { AxiosResponse } from "axios";
+import BigNumber from "bignumber.js";
 import * as fs from "fs";
-import { SmartContract } from "../smartcontracts/smartContract";
+import { PathLike } from "fs";
+import { IChainID, IGasLimit } from "../interface";
 import { Code } from "../smartcontracts/code";
+import { SmartContract } from "../smartcontracts/smartContract";
 import { AbiRegistry, TypedValue } from "../smartcontracts/typesystem";
 import { Transaction } from "../transaction";
 import { TransactionWatcher } from "../transactionWatcher";
-import { IChainID, IGasLimit } from "../interface";
 import { TestWallet } from "./wallets";
-import axios, { AxiosResponse } from "axios";
-import BigNumber from "bignumber.js";
 
 export async function prepareDeployment(obj: {
     deployer: TestWallet,
@@ -22,6 +22,7 @@ export async function prepareDeployment(obj: {
     let deployer = obj.deployer;
 
     let transaction = obj.contract.deploy({
+        owner: deployer.address,
         code: await loadContractCode(obj.codePath),
         gasLimit: obj.gasLimit,
         initArguments: obj.initArguments,
@@ -33,7 +34,7 @@ export async function prepareDeployment(obj: {
     transaction.setNonce(nonce);
     contract.setAddress(contractAddress);
     await deployer.signer.sign(transaction);
-    
+
     return transaction;
 }
 
@@ -50,7 +51,7 @@ export async function loadContractCode(path: PathLike): Promise<Code> {
         let buffer = Buffer.from(response.data);
         return Code.fromBuffer(buffer);
     }
-    
+
     // Load from file.
     let buffer: Buffer = await fs.promises.readFile(path);
     return Code.fromBuffer(buffer);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { Address } from "./address";
+import { Address, warnIfAddressIsNotSetOrZero } from "./address";
 import { TRANSACTION_MIN_GAS_PRICE } from "./constants";
 import * as errors from "./errors";
 import { Hash } from "./hash";
@@ -217,9 +217,10 @@ export class Transaction {
    * This function is called internally within the signing procedure.
    *
    * @param sender The address of the sender (will be provided when called within the signing procedure)
+   * TODO: in v12, remove the sender parameter (since it will be always provided in constructor).
    */
   toPlainObject(sender?: IAddress): IPlainTransactionObject {
-    return {
+    const plainObject = {
       nonce: this.nonce.valueOf(),
       value: this.value.toString(),
       receiver: this.receiver.bech32(),
@@ -232,6 +233,10 @@ export class Transaction {
       options: this.options.valueOf() == 0 ? undefined : this.options.valueOf(),
       signature: this.signature.hex() ? this.signature.hex() : undefined,
     };
+
+    warnIfAddressIsNotSetOrZero(new Address(plainObject.sender), "'transaction.sender' isn't properly set!");
+
+    return plainObject;
   }
 
   /**

--- a/src/transactionFactory.spec.ts
+++ b/src/transactionFactory.spec.ts
@@ -1,21 +1,29 @@
 import { assert } from "chai";
 import { Address } from "./address";
 import { GasEstimator } from "./gasEstimator";
+import { loadTestWallets, TestWallet } from "./testutils";
 import { TokenPayment } from "./tokenPayment";
 import { TransactionFactory } from "./transactionFactory";
 import { TransactionPayload } from "./transactionPayload";
 
 describe("test transaction factory", () => {
     const factory = new TransactionFactory(new GasEstimator());
+    let wallets: Record<string, TestWallet>;
+
+    before(async function () {
+        wallets = await loadTestWallets();
+    });
 
     it("should create EGLD transfers", () => {
         const transactionWithData = factory.createEGLDTransfer({
+            sender: wallets.alice.address,
             value: TokenPayment.egldFromAmount(10.5),
             receiver: new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"),
             data: new TransactionPayload("hello"),
             chainID: "D"
         });
 
+        assert.equal(transactionWithData.getSender().bech32(), wallets.alice.address.bech32());
         assert.equal(transactionWithData.getReceiver().bech32(), "erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha");
         assert.equal(transactionWithData.getValue(), "10500000000000000000");
         assert.equal(transactionWithData.getGasLimit(), 50000 + 5 * 1500);
@@ -23,11 +31,13 @@ describe("test transaction factory", () => {
         assert.equal(transactionWithData.getChainID(), "D");
 
         const transactionWithoutData = factory.createEGLDTransfer({
+            sender: wallets.alice.address,
             value: TokenPayment.egldFromAmount(10.5),
             receiver: new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"),
             chainID: "D"
         });
 
+        assert.equal(transactionWithoutData.getSender().bech32(), wallets.alice.address.bech32());
         assert.equal(transactionWithoutData.getReceiver().bech32(), "erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha");
         assert.equal(transactionWithoutData.getValue(), "10500000000000000000");
         assert.equal(transactionWithoutData.getGasLimit(), 50000);
@@ -37,11 +47,13 @@ describe("test transaction factory", () => {
 
     it("should create ESDT transfers", () => {
         const transaction = factory.createESDTTransfer({
+            sender: wallets.alice.address,
             payment: TokenPayment.fungibleFromAmount("COUNTER-8b028f", "100.00", 0),
             receiver: new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"),
             chainID: "D"
         });
 
+        assert.equal(transaction.getSender().bech32(), wallets.alice.address.bech32());
         assert.equal(transaction.getReceiver().bech32(), "erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha");
         assert.equal(transaction.getValue(), "");
         assert.equal(transaction.getGasLimit(), 50000 + 44 * 1500 + 200000 + 100000);

--- a/src/transactionFactory.ts
+++ b/src/transactionFactory.ts
@@ -1,7 +1,7 @@
+import { Address, warnIfAddressIsNotSetOrZero } from "./address";
 import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, ITokenPayment, ITransactionPayload, ITransactionValue } from "./interface";
 import { ESDTNFTTransferPayloadBuilder, ESDTTransferPayloadBuilder, MultiESDTNFTTransferPayloadBuilder } from "./tokenTransferBuilders";
 import { Transaction } from "./transaction";
-import {Address} from "./address";
 
 interface IGasEstimator {
     forEGLDTransfer(dataLength: number): number;
@@ -27,6 +27,8 @@ export class TransactionFactory {
         data?: ITransactionPayload;
         chainID: IChainID;
     }) {
+        warnIfAddressIsNotSetOrZero(args.sender, "For 'createEGLDTransfer()', the 'sender' should be specified!");
+
         const dataLength = args.data?.length() || 0;
         const estimatedGasLimit = this.gasEstimator.forEGLDTransfer(dataLength);
 
@@ -34,7 +36,8 @@ export class TransactionFactory {
             nonce: args.nonce,
             value: args.value,
             receiver: args.receiver,
-            sender: args.sender || Address.Zero(),
+            // TODO: in v12, remove the "|| new Address()" part ()
+            sender: args.sender || new Address(),
             gasPrice: args.gasPrice,
             gasLimit: args.gasLimit || estimatedGasLimit,
             data: args.data,
@@ -51,6 +54,8 @@ export class TransactionFactory {
         gasLimit?: IGasLimit;
         chainID: IChainID;
     }) {
+        warnIfAddressIsNotSetOrZero(args.sender, "For 'createESDTTransfer()', the 'sender' should be specified!");
+
         const transactionPayload = new ESDTTransferPayloadBuilder()
             .setPayment(args.payment)
             .build();
@@ -61,7 +66,8 @@ export class TransactionFactory {
         return new Transaction({
             nonce: args.nonce,
             receiver: args.receiver,
-            sender: args.sender || Address.Zero(),
+            // TODO: in v12, remove the "|| new Address()" part ()
+            sender: args.sender || new Address(),
             gasPrice: args.gasPrice,
             gasLimit: args.gasLimit || estimatedGasLimit,
             data: transactionPayload,


### PR DESCRIPTION
In v12, `sender` will be required on all components.