### PR TITLE
Ensure that sdk-core v11 works with sdk-wallet v4 (next)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,11 @@
       "devDependencies": {
         "@multiversx/sdk-network-providers": "1.2.1",
         "@multiversx/sdk-wallet": "3.0.0",
-        "@multiversx/sdk-wallet-next": "git+https://github.com/multiversx/mx-sdk-js-wallet.git#next-13",
+        "@multiversx/sdk-wallet-next": "npm:@multiversx/sdk-wallet@4.0.0",
         "@types/assert": "1.4.6",
         "@types/chai": "4.2.11",
         "@types/mocha": "9.1.0",
         "@types/node": "13.13.2",
-        "@types/protobufjs": "6.0.0",
         "assert": "2.0.0",
         "axios": "0.24.0",
         "browserify": "17.0.0",
@@ -37,6 +36,12 @@
         "tslint": "6.1.3",
         "typescript": "4.1.2"
       }
+    },
+    "@multiversx/sdk-wallet:4.0.0-beta.3": {
+      "extraneous": true
+    },
+    "@multiversx/sdk-wallet@4.0.0-beta.3": {
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -524,12 +529,14 @@
     },
     "node_modules/@multiversx/sdk-wallet-next": {
       "name": "@multiversx/sdk-wallet",
-      "version": "4.0.0-beta.2",
-      "resolved": "git+ssh://git@github.com/multiversx/mx-sdk-js-wallet.git#af6a418a154bcb9f002507fb8f9c54df7cb0cb13",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-4.0.0.tgz",
+      "integrity": "sha512-Fskqg9AGgqSIAgN+Ag9Y/DIoZRr4qgB0baVZ1nlXhgaRuM30v1UeW0TAIhuAbXkkMiTOJyLaCeebUDYy1VJgWA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",
+        "@noble/ed25519": "1.7.3",
+        "@noble/hashes": "1.3.0",
         "bech32": "1.1.4",
         "bip39": "3.0.2",
         "blake2b": "2.1.3",
@@ -568,6 +575,30 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -650,16 +681,6 @@
       "version": "13.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
       "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A=="
-    },
-    "node_modules/@types/protobufjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/protobufjs/-/protobufjs-6.0.0.tgz",
-      "integrity": "sha512-A27RDExpAf3rdDjIrHKiJK6x8kqqJ4CmoChwtipfhVAn1p7+wviQFFP7dppn8FslSbHtQeVPvi8wNKkDjSYjHw==",
-      "deprecated": "This is a stub types definition for protobufjs (https://github.com/dcodeIO/ProtoBuf.js). protobufjs provides its own type definitions, so you don't need @types/protobufjs installed!",
-      "dev": true,
-      "dependencies": {
-        "protobufjs": "*"
-      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -4766,11 +4787,14 @@
       }
     },
     "@multiversx/sdk-wallet-next": {
-      "version": "git+ssh://git@github.com/multiversx/mx-sdk-js-wallet.git#af6a418a154bcb9f002507fb8f9c54df7cb0cb13",
+      "version": "npm:@multiversx/sdk-wallet@4.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-4.0.0.tgz",
+      "integrity": "sha512-Fskqg9AGgqSIAgN+Ag9Y/DIoZRr4qgB0baVZ1nlXhgaRuM30v1UeW0TAIhuAbXkkMiTOJyLaCeebUDYy1VJgWA==",
       "dev": true,
-      "from": "@multiversx/sdk-wallet-next@git+https://github.com/multiversx/mx-sdk-js-wallet.git#next-13",
       "requires": {
         "@multiversx/sdk-bls-wasm": "0.3.5",
+        "@noble/ed25519": "1.7.3",
+        "@noble/hashes": "1.3.0",
         "bech32": "1.1.4",
         "bip39": "3.0.2",
         "blake2b": "2.1.3",
@@ -4793,6 +4817,18 @@
           }
         }
       }
+    },
+    "@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "dev": true
+    },
+    "@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "dev": true
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -4875,15 +4911,6 @@
       "version": "13.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
       "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A=="
-    },
-    "@types/protobufjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/protobufjs/-/protobufjs-6.0.0.tgz",
-      "integrity": "sha512-A27RDExpAf3rdDjIrHKiJK6x8kqqJ4CmoChwtipfhVAn1p7+wviQFFP7dppn8FslSbHtQeVPvi8wNKkDjSYjHw==",
-      "dev": true,
-      "requires": {
-        "protobufjs": "*"
-      }
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
       },
       "devDependencies": {
         "@multiversx/sdk-network-providers": "1.2.1",
-        "@multiversx/sdk-wallet": "2.1.1",
+        "@multiversx/sdk-wallet": "3.0.0",
+        "@multiversx/sdk-wallet-next": "git+https://github.com/multiversx/mx-sdk-js-wallet.git#next-13",
         "@types/assert": "1.4.6",
         "@types/chai": "4.2.11",
         "@types/mocha": "9.1.0",
@@ -421,19 +422,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@elrondnetwork/bls-wasm": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/bls-wasm/-/bls-wasm-0.3.3.tgz",
-      "integrity": "sha512-neCzWRk8pZsOBeAI3+t8jgiSkqj/y4IJPOMKG4ebL1+MiOFayygmfDvfZrK57RSoMWvDfXHlhTL25DrI+EtH+w==",
-      "dev": true,
-      "dependencies": {
-        "assert": "^2.0.0",
-        "perf_hooks": "0.0.1"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -481,6 +469,15 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@multiversx/sdk-bls-wasm": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-bls-wasm/-/sdk-bls-wasm-0.3.5.tgz",
+      "integrity": "sha512-c0tIdQUnbBLSt6NYU+OpeGPYdL0+GV547HeHT8Xc0BKQ7Cj0v82QUoA2QRtWrR1G4MNZmLsIacZSsf6DrIS2Bw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/@multiversx/sdk-network-providers": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.2.1.tgz",
@@ -508,12 +505,12 @@
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@multiversx/sdk-wallet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-2.1.1.tgz",
-      "integrity": "sha512-99wm+R8oLeNGuxnnbPiWVF1wHg81ev/IBU/2sAk/N7OX6ittY2+hRiSEN84Qv6186oJ/OgInEKtij4WwmdJuKw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-3.0.0.tgz",
+      "integrity": "sha512-nDVBtva1mpfutXA8TfUnpdeFqhY9O+deNU3U/Z41yPBcju1trHDC9gcKPyQqcQ3qjG/6LwEXmIm7Dc5fIsvVjg==",
       "dev": true,
       "dependencies": {
-        "@elrondnetwork/bls-wasm": "0.3.3",
+        "@multiversx/sdk-bls-wasm": "0.3.5",
         "bech32": "1.1.4",
         "bip39": "3.0.2",
         "blake2b": "2.1.3",
@@ -523,6 +520,39 @@
         "scryptsy": "2.1.0",
         "tweetnacl": "1.0.3",
         "uuid": "8.3.2"
+      }
+    },
+    "node_modules/@multiversx/sdk-wallet-next": {
+      "name": "@multiversx/sdk-wallet",
+      "version": "4.0.0-beta.2",
+      "resolved": "git+ssh://git@github.com/multiversx/mx-sdk-js-wallet.git#af6a418a154bcb9f002507fb8f9c54df7cb0cb13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@multiversx/sdk-bls-wasm": "0.3.5",
+        "bech32": "1.1.4",
+        "bip39": "3.0.2",
+        "blake2b": "2.1.3",
+        "ed25519-hd-key": "1.1.2",
+        "ed2curve": "0.3.0",
+        "keccak": "3.0.1",
+        "scryptsy": "2.1.0",
+        "tweetnacl": "1.0.3",
+        "uuid": "8.3.2"
+      }
+    },
+    "node_modules/@multiversx/sdk-wallet-next/node_modules/keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@multiversx/sdk-wallet/node_modules/keccak": {
@@ -3336,12 +3366,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/perf_hooks": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/perf_hooks/-/perf_hooks-0.0.1.tgz",
-      "integrity": "sha512-qG/D9iA4KDme+KF4vCObJy6Bouu3BlQnmJ8jPydVPm32NJBD9ZK1ZNgXSYaZKHkVC1sKSqUiLgFvAZPUiIEnBw==",
-      "dev": true
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -4639,16 +4663,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@elrondnetwork/bls-wasm": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/bls-wasm/-/bls-wasm-0.3.3.tgz",
-      "integrity": "sha512-neCzWRk8pZsOBeAI3+t8jgiSkqj/y4IJPOMKG4ebL1+MiOFayygmfDvfZrK57RSoMWvDfXHlhTL25DrI+EtH+w==",
-      "dev": true,
-      "requires": {
-        "assert": "^2.0.0",
-        "perf_hooks": "0.0.1"
-      }
-    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -4687,6 +4701,12 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@multiversx/sdk-bls-wasm": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-bls-wasm/-/sdk-bls-wasm-0.3.5.tgz",
+      "integrity": "sha512-c0tIdQUnbBLSt6NYU+OpeGPYdL0+GV547HeHT8Xc0BKQ7Cj0v82QUoA2QRtWrR1G4MNZmLsIacZSsf6DrIS2Bw==",
+      "dev": true
+    },
     "@multiversx/sdk-network-providers": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.2.1.tgz",
@@ -4716,12 +4736,41 @@
       }
     },
     "@multiversx/sdk-wallet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-2.1.1.tgz",
-      "integrity": "sha512-99wm+R8oLeNGuxnnbPiWVF1wHg81ev/IBU/2sAk/N7OX6ittY2+hRiSEN84Qv6186oJ/OgInEKtij4WwmdJuKw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-3.0.0.tgz",
+      "integrity": "sha512-nDVBtva1mpfutXA8TfUnpdeFqhY9O+deNU3U/Z41yPBcju1trHDC9gcKPyQqcQ3qjG/6LwEXmIm7Dc5fIsvVjg==",
       "dev": true,
       "requires": {
-        "@elrondnetwork/bls-wasm": "0.3.3",
+        "@multiversx/sdk-bls-wasm": "0.3.5",
+        "bech32": "1.1.4",
+        "bip39": "3.0.2",
+        "blake2b": "2.1.3",
+        "ed25519-hd-key": "1.1.2",
+        "ed2curve": "0.3.0",
+        "keccak": "3.0.1",
+        "scryptsy": "2.1.0",
+        "tweetnacl": "1.0.3",
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "keccak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "dev": true,
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        }
+      }
+    },
+    "@multiversx/sdk-wallet-next": {
+      "version": "git+ssh://git@github.com/multiversx/mx-sdk-js-wallet.git#af6a418a154bcb9f002507fb8f9c54df7cb0cb13",
+      "dev": true,
+      "from": "@multiversx/sdk-wallet-next@git+https://github.com/multiversx/mx-sdk-js-wallet.git#next-13",
+      "requires": {
+        "@multiversx/sdk-bls-wasm": "0.3.5",
         "bech32": "1.1.4",
         "bip39": "3.0.2",
         "blake2b": "2.1.3",
@@ -6988,12 +7037,6 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
-    },
-    "perf_hooks": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/perf_hooks/-/perf_hooks-0.0.1.tgz",
-      "integrity": "sha512-qG/D9iA4KDme+KF4vCObJy6Bouu3BlQnmJ8jPydVPm32NJBD9ZK1ZNgXSYaZKHkVC1sKSqUiLgFvAZPUiIEnBw==",
-      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "devDependencies": {
     "@multiversx/sdk-network-providers": "1.2.1",
-    "@multiversx/sdk-wallet": "2.1.1",
+    "@multiversx/sdk-wallet": "3.0.0",
+    "@multiversx/sdk-wallet-next": "git+https://github.com/multiversx/mx-sdk-js-wallet.git#next-13",
     "@types/assert": "1.4.6",
     "@types/chai": "4.2.11",
     "@types/mocha": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,11 @@
   "devDependencies": {
     "@multiversx/sdk-network-providers": "1.2.1",
     "@multiversx/sdk-wallet": "3.0.0",
-    "@multiversx/sdk-wallet-next": "git+https://github.com/multiversx/mx-sdk-js-wallet.git#next-13",
+    "@multiversx/sdk-wallet-next": "npm:@multiversx/sdk-wallet@4.0.0",
     "@types/assert": "1.4.6",
     "@types/chai": "4.2.11",
     "@types/mocha": "9.1.0",
     "@types/node": "13.13.2",
-    "@types/protobufjs": "6.0.0",
     "assert": "2.0.0",
     "axios": "0.24.0",
     "browserify": "17.0.0",

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -1,4 +1,5 @@
 import { UserSecretKey, UserSigner } from "@multiversx/sdk-wallet";
+import { UserSigner as UserSignerNext } from "@multiversx/sdk-wallet-next";
 import axios from "axios";
 import * as fs from "fs";
 import * as path from "path";
@@ -72,6 +73,7 @@ export class TestWallet {
     readonly secretKeyHex: string;
     readonly secretKey: Buffer;
     readonly signer: UserSigner;
+    readonly signerNext: UserSignerNext;
     readonly keyFileObject: any;
     readonly pemFileText: any;
     readonly account: Account;
@@ -81,6 +83,7 @@ export class TestWallet {
         this.secretKeyHex = secretKeyHex;
         this.secretKey = Buffer.from(secretKeyHex, "hex");
         this.signer = new UserSigner(UserSecretKey.fromString(secretKeyHex));
+        this.signerNext = new UserSignerNext(UserSecretKey.fromString(secretKeyHex));
         this.keyFileObject = keyFileObject;
         this.pemFileText = pemFileText;
         this.account = new Account(this.address);

--- a/src/transaction.local.net.spec.ts
+++ b/src/transaction.local.net.spec.ts
@@ -47,8 +47,8 @@ describe("test transaction", function () {
         alice.account.incrementNonce();
         transactionTwo.setNonce(alice.account.nonce);
 
-        await signTransaction(transactionOne, alice);
-        await signTransaction(transactionTwo, alice);
+        await signTransaction({ transaction: transactionOne, wallet: alice });
+        await signTransaction({ transaction: transactionTwo, wallet: alice });
 
         await provider.sendTransaction(transactionOne);
         await provider.sendTransaction(transactionTwo);
@@ -90,14 +90,17 @@ describe("test transaction", function () {
         transactionOne.setNonce(alice.account.nonce);
         transactionTwo.setNonce(alice.account.nonce);
 
-        await signTransaction(transactionOne, alice);
-        await signTransaction(transactionTwo, alice);
+        await signTransaction({ transaction: transactionOne, wallet: alice });
+        await signTransaction({ transaction: transactionTwo, wallet: alice });
 
         Logger.trace(JSON.stringify(await provider.simulateTransaction(transactionOne), null, 4));
         Logger.trace(JSON.stringify(await provider.simulateTransaction(transactionTwo), null, 4));
     });
 
-    async function signTransaction(transaction: Transaction, wallet: TestWallet) {
+    async function signTransaction(options: { transaction: Transaction, wallet: TestWallet }) {
+        const transaction = options.transaction;
+        const wallet = options.wallet;
+
         const serialized = transaction.serializeForSigning(transaction.getSender());
         const signature = await wallet.signerNext.sign(serialized);
         transaction.applySignature(signature, transaction.getSender());

--- a/src/transaction.local.net.spec.ts
+++ b/src/transaction.local.net.spec.ts
@@ -47,8 +47,8 @@ describe("test transaction", function () {
         alice.account.incrementNonce();
         transactionTwo.setNonce(alice.account.nonce);
 
-        await alice.signer.sign(transactionOne);
-        await alice.signer.sign(transactionTwo);
+        await signTransaction(transactionOne, alice);
+        await signTransaction(transactionTwo, alice);
 
         await provider.sendTransaction(transactionOne);
         await provider.sendTransaction(transactionTwo);
@@ -90,10 +90,16 @@ describe("test transaction", function () {
         transactionOne.setNonce(alice.account.nonce);
         transactionTwo.setNonce(alice.account.nonce);
 
-        await alice.signer.sign(transactionOne);
-        await alice.signer.sign(transactionTwo);
+        await signTransaction(transactionOne, alice);
+        await signTransaction(transactionTwo, alice);
 
         Logger.trace(JSON.stringify(await provider.simulateTransaction(transactionOne), null, 4));
         Logger.trace(JSON.stringify(await provider.simulateTransaction(transactionTwo), null, 4));
     });
+
+    async function signTransaction(transaction: Transaction, wallet: TestWallet) {
+        const serialized = transaction.serializeForSigning(transaction.getSender());
+        const signature = await wallet.signerNext.sign(serialized);
+        transaction.applySignature(signature, transaction.getSender());
+    }
 });

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -267,8 +267,13 @@ export class Transaction {
    * @param signature The signature, as computed by a signer.
    * @param signedBy The address of the signer.
    */
-  applySignature(signature: ISignature, signedBy: IAddress) {
-    this.signature = signature;
+  applySignature(signature: ISignature | Buffer, signedBy: IAddress) {
+    if (signature instanceof Buffer) {
+      this.signature = new Signature(signature);
+    } else {
+      this.signature = signature;
+    }
+
     this.sender = signedBy;
     this.hash = TransactionHash.compute(this);
   }


### PR DESCRIPTION
Ensure that `sdk-core v11` works (will work) with `sdk-wallet v4` (next) - with small changes when using signers.

Sign transaction using `sdk-core v11` and `sdk-wallet v3`:

```
await signer.sign(transaction);
```

Sign transaction using `sdk-core v11` and `sdk-wallet v4 (next)`:

```
const serialized = transaction.serializeForSigning(transaction.getSender());
const signature = await signer.sign(serialized);
transaction.applySignature(signature, transaction.getSender());
```

In `sdk-core v12`, this will become:

```
const serialized: Buffer = transaction.serializeForSigning();
const signature: Buffer = await signer.sign(serialized);
transaction.applySignature(signature);
```

Related PR (of `sdk-wallet v4`):
 - https://github.com/multiversx/mx-sdk-js-wallet/pull/23