### PR TITLE
Adjust interface of transaction

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -32,6 +32,8 @@ export interface INonce { valueOf(): number; }
 export interface IChainID { valueOf(): string; }
 export interface IGasLimit { valueOf(): number; }
 export interface IGasPrice { valueOf(): number; }
+export interface ITransactionVersion { valueOf(): number; }
+export interface ITransactionOptions { valueOf(): number; }
 
 export interface ITransactionPayload {
     length(): number;

--- a/src/smartcontracts/smartContract.spec.ts
+++ b/src/smartcontracts/smartContract.spec.ts
@@ -33,7 +33,7 @@ describe("test contract", () => {
         setupUnitTestWatcherTimeouts();
         let watcher = new TransactionWatcher(provider);
 
-        let contract = new SmartContract({});
+        let contract = new SmartContract();
         let deployTransaction = contract.deploy({
             code: Code.fromBuffer(Buffer.from([1, 2, 3, 4])),
             gasLimit: 1000000,

--- a/src/smartcontracts/smartContract.ts
+++ b/src/smartcontracts/smartContract.ts
@@ -42,11 +42,11 @@ export class SmartContract implements ISmartContract {
     /**
      * Create a SmartContract object by providing its address on the Network.
      */
-    constructor({ address, abi }: { address?: IAddress, abi?: SmartContractAbi }) {
-        this.address = address || new Address();
-        this.abi = abi;
+    constructor(options: { address?: IAddress, abi?: SmartContractAbi } = {}) {
+        this.address = options.address || new Address();
+        this.abi = options.abi;
 
-        if (abi) {
+        if (this.abi) {
             this.setupMethods();
         }
     }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -61,13 +61,13 @@ export class Transaction {
 
   /**
    * The version, required by the Network in order to correctly interpret the contents of the transaction.
-   * @deprecated Use {setVersion()} instead.
+   * @deprecated Use getVersion() and setVersion() instead.
    */
   version: TransactionVersion;
 
   /**
    * The options field, useful for describing different settings available for transactions
-   * @deprecated Use {setOptions()} instead.
+   * @deprecated Use getOptions() and setOptions() instead.
    */
   options: TransactionOptions;
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -61,13 +61,15 @@ export class Transaction {
 
   /**
    * The version, required by the Network in order to correctly interpret the contents of the transaction.
+   * @deprecated Use {setVersion()} instead.
    */
-  private version: TransactionVersion;
+  version: TransactionVersion;
 
   /**
    * The options field, useful for describing different settings available for transactions
+   * @deprecated Use {setOptions()} instead.
    */
-  private options: TransactionOptions;
+  options: TransactionOptions;
 
   /**
    * The address of the guardian.
@@ -206,7 +208,10 @@ export class Transaction {
   }
 
   getOptions(): TransactionOptions {
-    return this.options;
+    // Make sure that "sdk-core v12" is compatible (for a while) with (older) libraries that were previously setting the (soon to be private) "options" field directly,
+    // instead of using the "setOptions()" method.
+    const options = new TransactionOptions(this.options.valueOf());
+    return options;
   }
 
   setOptions(options: ITransactionOptions) {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -4,7 +4,7 @@ import { Compatibility } from "./compatibility";
 import { TRANSACTION_MIN_GAS_PRICE } from "./constants";
 import * as errors from "./errors";
 import { Hash } from "./hash";
-import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, IPlainTransactionObject, ISignature, ITransactionPayload, ITransactionValue } from "./interface";
+import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, IPlainTransactionObject, ISignature, ITransactionOptions, ITransactionPayload, ITransactionValue, ITransactionVersion } from "./interface";
 import { INetworkConfig } from "./interfaceOfNetwork";
 import { TransactionOptions, TransactionVersion } from "./networkParams";
 import { ProtoSerializer } from "./proto";
@@ -62,12 +62,12 @@ export class Transaction {
   /**
    * The version, required by the Network in order to correctly interpret the contents of the transaction.
    */
-  version: TransactionVersion;
+  private version: TransactionVersion;
 
   /**
    * The options field, useful for describing different settings available for transactions
    */
-  options: TransactionOptions;
+  private options: TransactionOptions;
 
   /**
    * The address of the guardian.
@@ -113,8 +113,8 @@ export class Transaction {
     gasLimit: IGasLimit;
     data?: ITransactionPayload;
     chainID: IChainID;
-    version?: TransactionVersion;
-    options?: TransactionOptions;
+    version?: ITransactionVersion;
+    options?: ITransactionOptions;
     guardian?: IAddress;
   }) {
     this.nonce = nonce || 0;
@@ -125,8 +125,8 @@ export class Transaction {
     this.gasLimit = gasLimit;
     this.data = data || new TransactionPayload();
     this.chainID = chainID;
-    this.version = version || TransactionVersion.withDefaultVersion();
-    this.options = options || TransactionOptions.withDefaultOptions();
+    this.version = version ? new TransactionVersion(version.valueOf()) : TransactionVersion.withDefaultVersion();
+    this.options = options ? new TransactionOptions(options.valueOf()) : TransactionOptions.withDefaultOptions();
     this.guardian = guardian || Address.empty();
 
     this.signature = Buffer.from([]);
@@ -201,8 +201,16 @@ export class Transaction {
     return this.version;
   }
 
+  setVersion(version: ITransactionVersion) {
+    this.version = new TransactionVersion(version.valueOf());
+  }
+
   getOptions(): TransactionOptions {
     return this.options;
+  }
+
+  setOptions(options: ITransactionOptions) {
+    this.options = new TransactionOptions(options.valueOf());
   }
 
   getSignature(): Buffer {

--- a/src/transferTransactionsFactory.spec.ts
+++ b/src/transferTransactionsFactory.spec.ts
@@ -11,11 +11,13 @@ describe("test transaction factory", () => {
     it("should create EGLD transfers", () => {
         const transactionWithData = factory.createEGLDTransfer({
             value: TokenTransfer.egldFromAmount(10.5),
+            sender: Address.fromBech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"),
             receiver: new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"),
             data: new TransactionPayload("hello"),
             chainID: "D"
         });
 
+        assert.equal(transactionWithData.getSender().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
         assert.equal(transactionWithData.getReceiver().bech32(), "erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha");
         assert.equal(transactionWithData.getValue(), "10500000000000000000");
         assert.equal(transactionWithData.getGasLimit(), 50000 + 5 * 1500);
@@ -24,10 +26,12 @@ describe("test transaction factory", () => {
 
         const transactionWithoutData = factory.createEGLDTransfer({
             value: TokenTransfer.egldFromAmount(10.5),
+            sender: Address.fromBech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"),
             receiver: new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"),
             chainID: "D"
         });
 
+        assert.equal(transactionWithoutData.getSender().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
         assert.equal(transactionWithoutData.getReceiver().bech32(), "erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha");
         assert.equal(transactionWithoutData.getValue(), "10500000000000000000");
         assert.equal(transactionWithoutData.getGasLimit(), 50000);
@@ -38,10 +42,12 @@ describe("test transaction factory", () => {
     it("should create ESDT transfers", () => {
         const transaction = factory.createESDTTransfer({
             tokenTransfer: TokenTransfer.fungibleFromAmount("TEST-8b028f", "100.00", 2),
-            receiver: new Address("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"),
+            sender: Address.fromBech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"),
+            receiver: Address.fromBech32("erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha"),
             chainID: "D"
         });
 
+        assert.equal(transaction.getSender().bech32(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
         assert.equal(transaction.getReceiver().bech32(), "erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha");
         assert.equal(transaction.getValue(), "");
         assert.equal(transaction.getGasLimit(), 50000 + 40 * 1500 + 200000 + 100000);

--- a/src/transferTransactionsFactory.ts
+++ b/src/transferTransactionsFactory.ts
@@ -1,4 +1,3 @@
-import { Address } from "./address";
 import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, ITokenTransfer, ITransactionPayload, ITransactionValue } from "./interface";
 import { ArgSerializer } from "./smartcontracts/argSerializer";
 import { AddressValue, BigUIntValue, BytesValue, TypedValue, U16Value, U64Value } from "./smartcontracts/typesystem";
@@ -23,7 +22,7 @@ export class TransferTransactionsFactory {
         nonce?: INonce;
         value: ITransactionValue;
         receiver: IAddress;
-        sender?: IAddress;
+        sender: IAddress;
         gasPrice?: IGasPrice;
         gasLimit?: IGasLimit;
         data?: ITransactionPayload;
@@ -36,7 +35,7 @@ export class TransferTransactionsFactory {
             nonce: args.nonce,
             value: args.value,
             receiver: args.receiver,
-            sender: args.sender || Address.Zero(),
+            sender: args.sender,
             gasPrice: args.gasPrice,
             gasLimit: args.gasLimit || estimatedGasLimit,
             data: args.data,
@@ -48,7 +47,7 @@ export class TransferTransactionsFactory {
         tokenTransfer: ITokenTransfer,
         nonce?: INonce;
         receiver: IAddress;
-        sender?: IAddress;
+        sender: IAddress;
         gasPrice?: IGasPrice;
         gasLimit?: IGasLimit;
         chainID: IChainID;
@@ -68,7 +67,7 @@ export class TransferTransactionsFactory {
         return new Transaction({
             nonce: args.nonce,
             receiver: args.receiver,
-            sender: args.sender || Address.Zero(),
+            sender: args.sender,
             gasPrice: args.gasPrice,
             gasLimit: args.gasLimit || estimatedGasLimit,
             data: transactionPayload,


### PR DESCRIPTION
Breaking change - previously described: `sender` is now mandatory when creating transactions.

Deprecated:
 - `transaction.options`, `transaction.version`. Use the `get*` and `set*` functions, instead.