### PR TITLE
Fix design inconsistency (post-release): message.getSignature() should also be a "Buffer"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.0.1",
+      "version": "12.1.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/signableMessage.spec.ts
+++ b/src/signableMessage.spec.ts
@@ -1,6 +1,5 @@
 import { assert } from "chai";
 import { SignableMessage } from "./signableMessage";
-import { Signature } from "./signature";
 import { loadTestWallets, TestWallet } from "./testutils";
 
 
@@ -13,7 +12,7 @@ describe("test signable message", () => {
         const sm = new SignableMessage({
             address: alice.address,
             message: Buffer.from("test message", "ascii"),
-            signature: new Signature(Buffer.from("a".repeat(128), "hex"),),
+            signature: Buffer.from("a".repeat(128), "hex"),
             signer: "ElrondWallet"
         });
 

--- a/src/signableMessage.ts
+++ b/src/signableMessage.ts
@@ -1,6 +1,5 @@
-import { ISignature } from "./interface";
-import { Signature } from "./signature";
 import { Address } from "./address";
+import { ISignature } from "./interface";
 const createKeccakHash = require("keccak");
 
 export const MESSAGE_PREFIX = "\x17Elrond Signed Message:\n";
@@ -14,7 +13,7 @@ export class SignableMessage {
   /**
    * Signature obtained by a signer of type @param signer .
    */
-  signature: ISignature;
+  signature: Buffer;
 
   /**
    * Address of the wallet that performed the signing operation
@@ -33,7 +32,7 @@ export class SignableMessage {
 
   public constructor(init?: Partial<SignableMessage>) {
     this.message = Buffer.from([]);
-    this.signature = new Signature();
+    this.signature = Buffer.from([]);
     this.version = 1;
     this.signer = "ErdJS";
     this.address = new Address();
@@ -53,12 +52,16 @@ export class SignableMessage {
     return Buffer.concat([this.getMessageSize(), this.message]);
   }
 
-  getSignature(): ISignature {
+  getSignature(): Buffer {
     return this.signature;
   }
 
-  applySignature(signature: ISignature): void {
-    this.signature = signature;
+  applySignature(signature: ISignature | Buffer) {
+    if (signature instanceof Buffer) {
+      this.signature = signature;
+    } else {
+      this.signature = Buffer.from(signature.hex(), "hex");
+    }
   }
 
   getMessageSize(): Buffer {
@@ -71,8 +74,8 @@ export class SignableMessage {
   toJSON(): object {
     return {
       address: this.address.bech32(),
-      message: "0x" + this.message.toString('hex'),
-      signature: "0x" + this.signature.hex(),
+      message: "0x" + this.message.toString("hex"),
+      signature: "0x" + this.signature.toString("hex"),
       version: this.version,
       signer: this.signer,
     };


### PR DESCRIPTION
Just like `transaction.getSignature()`, `signableMessage.getSignature()` should also be a buffer.

Theoretically, this is a breaking change. Practically, it is not - the major release has only been published for ~1 hour.