### PR TITLE
Change BinaryCodecConstraints default values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.1.0",
+      "version": "12.1.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/smartcontracts/codec/binary.spec.ts
+++ b/src/smartcontracts/codec/binary.spec.ts
@@ -1,3 +1,4 @@
+import * as errors from "../../errors";
 import { assert } from "chai";
 import { BinaryCodec, BinaryCodecConstraints } from "./binary";
 import { AddressType, AddressValue, BigIntType, BigUIntType, BigUIntValue, BooleanType, BooleanValue, I16Type, I32Type, I64Type, I8Type, NumericalType, NumericalValue, Struct, Field, StructType, TypedValue, U16Type, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, List, ListType, EnumType, EnumVariantDefinition, EnumValue, ArrayVec, ArrayVecType, U16Value, TokenIdentifierType, TokenIdentifierValue, StringValue, StringType } from "../typesystem";
@@ -90,7 +91,7 @@ describe("test binary codec (basic)", () => {
 
         let length = [0x00, 0x00, 0x00, 0x04];
         let payload = [0x74, 0x65, 0x73, 0x74];
-        
+
         assert.deepEqual(codec.encodeNested(bytesValue), Buffer.from([...length, ...payload]));
         assert.deepEqual(codec.encodeTopLevel(bytesValue), Buffer.from(payload));
         assert.deepEqual(codec.decodeNested<BytesValue>(Buffer.from([...length, ...payload]), new BytesType()), [bytesValue, 8]);
@@ -127,6 +128,27 @@ describe("test binary codec (advanced)", () => {
 
         assert.deepEqual(decodedNested, list);
         assert.deepEqual(decodedTopLevel, list);
+    });
+
+    it("should fail with large lists using default constraints", async () => {
+        let numItems = 2 ** 17;
+        let codec = new BinaryCodec();
+
+        let items: TypedValue[] = [];
+
+        for (let i = 0; i < numItems; i++) {
+            items.push(new U32Value(i));
+        }
+
+        let list = new List(new ListType(new U32Type()), items);
+
+        assert.throws(() => {
+            codec.encodeNested(list);
+        }, errors.ErrCodec);
+
+        assert.throws(() => {
+            codec.encodeTopLevel(list);
+        }, errors.ErrCodec);
     });
 
     it("benchmark: should work well with large lists", async function () {

--- a/src/smartcontracts/codec/binary.spec.ts
+++ b/src/smartcontracts/codec/binary.spec.ts
@@ -144,11 +144,11 @@ describe("test binary codec (advanced)", () => {
 
         assert.throws(() => {
             codec.encodeNested(list);
-        }, errors.ErrCodec);
+        }, errors.ErrCodec, `List too large: ${numItems} > ${codec.constraints.maxListLength}`);
 
         assert.throws(() => {
             codec.encodeTopLevel(list);
-        }, errors.ErrCodec);
+        }, errors.ErrCodec, `List too large: ${numItems} > ${codec.constraints.maxListLength}`);
     });
 
     it("benchmark: should work well with large lists", async function () {

--- a/src/smartcontracts/codec/binary.ts
+++ b/src/smartcontracts/codec/binary.ts
@@ -125,8 +125,8 @@ export class BinaryCodecConstraints {
     maxListLength: number;
 
     constructor(init?: Partial<BinaryCodecConstraints>) {
-        this.maxBufferLength = init?.maxBufferLength || 40960;
-        this.maxListLength = init?.maxListLength || 8192;
+        this.maxBufferLength = init?.maxBufferLength || 256000;
+        this.maxListLength = init?.maxListLength || 128000;
     }
 
     checkBufferLength(buffer: Buffer) {


### PR DESCRIPTION
This PR solves this [issue](https://github.com/multiversx/mx-sdk-js-core/issues/286).

Previous default values:
`maxBufferLength = 40960`
`maxListLength = 8192`

Current default values:
`maxBufferLength = 256000`
`maxListLength = 128000`

Also added a unit test.