### PR TITLE
Workaround: fix import of "proto"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.2.0",
+      "version": "12.2.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/proto/serializer.ts
+++ b/src/proto/serializer.ts
@@ -5,7 +5,7 @@ import * as errors from "../errors";
 import { ITransactionValue } from "../interface";
 import { bigIntToBuffer } from "../smartcontracts/codec/utils";
 import { Transaction } from "../transaction";
-import { proto } from "./compiled";
+
 /**
  * Hides away the serialization complexity, for each type of object (e.g. transactions).
  
@@ -16,6 +16,7 @@ export class ProtoSerializer {
      * Serializes a Transaction object to a Buffer. Handles low-level conversion logic and field-mappings as well.
      */
     serializeTransaction(transaction: Transaction): Buffer {
+        const proto = require("./compiled").proto;
         const receiverPubkey = new Address(transaction.getReceiver().bech32()).pubkey();
         const senderPubkey = new Address(transaction.getSender().bech32()).pubkey();
 


### PR DESCRIPTION
Avoid namespace pollution - `compiled.js` seems to do bad namespace management, which results into conflicting serialization logic among different versions of `sdk-core`. 