### PR TITLE
Toggle global burn, registerAndSetAllRoles etc.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.2.1",
+  "version": "12.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.2.1",
+      "version": "12.3.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.2.1",
+  "version": "12.3.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/tokenOperations/tokenOperationsFactory.spec.ts
+++ b/src/tokenOperations/tokenOperationsFactory.spec.ts
@@ -22,15 +22,13 @@ describe("test factory", () => {
             canFreeze: true,
             canWipe: true,
             canPause: true,
-            canMint: true,
-            canBurn: true,
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
             transactionNonce: 42
         });
 
-        assert.equal(transaction.getData().toString(), "issue@4652414e4b@4652414e4b@64@@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4d696e74@74727565@63616e4275726e@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565")
+        assert.equal(transaction.getData().toString(), "issue@4652414e4b@4652414e4b@64@@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565")
         assert.equal(transaction.getNonce(), 42);
         assert.equal(transaction.getSender().toString(), frank.address.toString());
         assert.equal(transaction.getReceiver().toString(), "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");

--- a/src/tokenOperations/tokenOperationsFactory.spec.ts
+++ b/src/tokenOperations/tokenOperationsFactory.spec.ts
@@ -12,6 +12,22 @@ describe("test factory", () => {
         factory = new TokenOperationsFactory(new TokenOperationsFactoryConfig("T"));
     });
 
+    it("should create <registerAndSetAllRoles>", () => {
+        const transaction = factory.registerAndSetAllRoles({
+            issuer: frank.address,
+            tokenName: "TEST",
+            tokenTicker: "TEST",
+            tokenType: "FNG",
+            numDecimals: 2,
+            transactionNonce: 42
+        });
+
+        assert.equal(transaction.getData().toString(), "registerAndSetAllRoles@54455354@54455354@464e47@02")
+        assert.equal(transaction.getNonce(), 42);
+        assert.equal(transaction.getSender().toString(), frank.address.toString());
+        assert.equal(transaction.getReceiver().toString(), "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");
+    });
+
     it("should create <issueFungible>", () => {
         const transaction = factory.issueFungible({
             issuer: frank.address,

--- a/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
+++ b/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
@@ -33,10 +33,97 @@ describe("test factory on testnet", function () {
         transferTransactionsFactory = new TransferTransactionsFactory(new GasEstimator());
     });
 
-    it.only("should issue fungible, then toggle global burn", async function () {
+    it("should register and set all roles (FNG)", async function () {
+        this.timeout(120000);
+        await frank.sync(provider);
+
+        const tx1 = factory.registerAndSetAllRoles({
+            issuer: frank.address,
+            tokenName: "TEST",
+            tokenTicker: "TEST",
+            tokenType: "FNG",
+            numDecimals: 2,
+            transactionNonce: frank.account.nonce
+        });
+
+        const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
+        const tx1Outcome = parser.parseRegisterAndSetAllRoles(tx1OnNetwork);
+
+        assert.isTrue(tx1Outcome.tokenIdentifier.includes("TEST"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleLocalMint"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleLocalBurn"));
+    });
+
+    it("should register and set all roles (NFT)", async function () {
+        this.timeout(120000);
+        await frank.sync(provider);
+
+        const tx1 = factory.registerAndSetAllRoles({
+            issuer: frank.address,
+            tokenName: "TEST",
+            tokenTicker: "TEST",
+            tokenType: "NFT",
+            numDecimals: 0,
+            transactionNonce: frank.account.nonce
+        });
+
+        const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
+        const tx1Outcome = parser.parseRegisterAndSetAllRoles(tx1OnNetwork);
+
+        assert.isTrue(tx1Outcome.tokenIdentifier.includes("TEST"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTCreate"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTBurn"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTUpdateAttributes"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTAddURI"));
+    });
+
+    it("should register and set all roles (SFT)", async function () {
+        this.timeout(120000);
+        await frank.sync(provider);
+
+        const tx1 = factory.registerAndSetAllRoles({
+            issuer: frank.address,
+            tokenName: "TEST",
+            tokenTicker: "TEST",
+            tokenType: "SFT",
+            numDecimals: 0,
+            transactionNonce: frank.account.nonce
+        });
+
+        const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
+        const tx1Outcome = parser.parseRegisterAndSetAllRoles(tx1OnNetwork);
+
+        assert.isTrue(tx1Outcome.tokenIdentifier.includes("TEST"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTCreate"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTBurn"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTAddQuantity"));
+    });
+
+    it("should register and set all roles (META)", async function () {
+        this.timeout(120000);
+        await frank.sync(provider);
+
+        const tx1 = factory.registerAndSetAllRoles({
+            issuer: frank.address,
+            tokenName: "TEST",
+            tokenTicker: "TEST",
+            tokenType: "META",
+            numDecimals: 2,
+            transactionNonce: frank.account.nonce
+        });
+
+        const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
+        const tx1Outcome = parser.parseRegisterAndSetAllRoles(tx1OnNetwork);
+
+        assert.isTrue(tx1Outcome.tokenIdentifier.includes("TEST"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTCreate"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTBurn"));
+        assert.isTrue(tx1Outcome.roles.includes("ESDTRoleNFTAddQuantity"));
+    });
+
+    it("should issue fungible, then toggle global burn", async function () {
         this.timeout(180000);
         await frank.sync(provider);
-        await grace.sync(provider);
 
         // Issue
         const tx1 = factory.issueFungible({

--- a/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
+++ b/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
@@ -69,7 +69,7 @@ describe("test factory on testnet", function () {
         });
 
         const tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
-        const _tx2Outcome = parser.parseToggleBurnRoleGlobally(tx2OnNetwork);
+        const _tx2Outcome = parser.parseUnsetBurnRoleGlobally(tx2OnNetwork);
 
         // Set global burn
         const tx3 = factory.setBurnRoleGlobally({
@@ -79,7 +79,7 @@ describe("test factory on testnet", function () {
         });
 
         const tx3OnNetwork = await processTransaction(frank, tx3, "tx3");
-        const _tx3Outcome = parser.parseToggleBurnRoleGlobally(tx3OnNetwork);
+        const _tx3Outcome = parser.parseSetBurnRoleGlobally(tx3OnNetwork);
     });
 
     it("should issue fungible, mint, burn", async function () {

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { ARGUMENTS_SEPARATOR, TRANSACTION_OPTIONS_DEFAULT, TRANSACTION_VERSION_DEFAULT } from "../constants";
 import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, ITransactionValue } from "../interface";
+import { Logger } from "../logger";
 import { TransactionOptions, TransactionVersion } from "../networkParams";
 import { Transaction } from "../transaction";
 import { TransactionPayload } from "../transactionPayload";
@@ -26,8 +27,6 @@ interface IConfig {
     gasLimitStorePerByte: IGasLimit;
     issueCost: BigNumber.Value;
     esdtContractAddress: IAddress;
-
-    shouldWarnAboutUnsettingBurnRoleGlobally: boolean;
 }
 
 interface IBaseArgs {
@@ -198,7 +197,7 @@ export class TokenOperationsFactory {
     }
 
     issueFungible(args: IIssueFungibleArgs): Transaction {
-        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+        this.notifyAboutUnsettingBurnRoleGlobally();
 
         const parts = [
             "issue",
@@ -226,12 +225,8 @@ export class TokenOperationsFactory {
         });
     }
 
-    private warnAboutUnsettingBurnRoleGloballyIfAppropriate() {
-        if (!this.config.shouldWarnAboutUnsettingBurnRoleGlobally) {
-            return;
-        }
-
-        console.warn(`
+    private notifyAboutUnsettingBurnRoleGlobally() {
+        Logger.info(`
 ==========
 IMPORTANT!
 ==========
@@ -240,7 +235,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
     }
 
     issueSemiFungible(args: IIssueSemiFungibleArgs): Transaction {
-        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+        this.notifyAboutUnsettingBurnRoleGlobally();
 
         const parts = [
             "issueSemiFungible",
@@ -268,7 +263,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
     }
 
     issueNonFungible(args: IIssueNonFungibleArgs): Transaction {
-        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+        this.notifyAboutUnsettingBurnRoleGlobally();
 
         const parts = [
             "issueNonFungible",
@@ -296,7 +291,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
     }
 
     registerMetaESDT(args: IRegisterMetaESDT): Transaction {
-        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+        this.notifyAboutUnsettingBurnRoleGlobally();
 
         const parts = [
             "registerMetaESDT",
@@ -325,7 +320,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
     }
 
     registerAndSetAllRoles(args: IRegisterAndSetAllRoles): Transaction {
-        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+        this.notifyAboutUnsettingBurnRoleGlobally();
 
         const parts = [
             "registerAndSetAllRoles",

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -72,6 +72,16 @@ interface IRegisterMetaESDT extends IIssueSemiFungibleArgs {
     numDecimals: number;
 }
 
+interface IRegisterAndSetAllRoles extends IBaseArgs {
+    issuer: IAddress;
+    tokenName: string;
+    tokenTicker: string;
+    tokenType: RegisterAndSetAllRolesTokenType;
+    numDecimals: number;
+}
+
+type RegisterAndSetAllRolesTokenType = "NFT" | "SFT" | "META" | "FNG";
+
 interface IToggleBurnRoleGloballyArgs extends IBaseArgs {
     manager: IAddress;
     tokenIdentifier: string;
@@ -272,6 +282,27 @@ export class TokenOperationsFactory {
             ...(args.canChangeOwner ? [utf8ToHex("canChangeOwner"), this.trueAsHex] : []),
             ...(args.canUpgrade ? [utf8ToHex("canUpgrade"), this.trueAsHex] : []),
             ...(args.canAddSpecialRoles ? [utf8ToHex("canAddSpecialRoles"), this.trueAsHex] : []),
+        ];
+
+        return this.createTransaction({
+            sender: args.issuer,
+            receiver: this.config.esdtContractAddress,
+            nonce: args.transactionNonce,
+            value: this.config.issueCost,
+            gasPrice: args.gasPrice,
+            gasLimitHint: args.gasLimit,
+            executionGasLimit: this.config.gasLimitIssue,
+            dataParts: parts
+        });
+    }
+
+    registerAndSetAllRoles(args: IRegisterAndSetAllRoles): Transaction {
+        const parts = [
+            "registerAndSetAllRoles",
+            utf8ToHex(args.tokenName),
+            utf8ToHex(args.tokenTicker),
+            utf8ToHex(args.tokenType),
+            bigIntToHex(args.numDecimals)
         ];
 
         return this.createTransaction({

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -12,6 +12,7 @@ interface IConfig {
     minGasLimit: IGasLimit;
     gasLimitPerByte: IGasLimit;
     gasLimitIssue: IGasLimit;
+    gasLimitToggleBurnRoleGlobally: IGasLimit;
     gasLimitESDTLocalMint: IGasLimit;
     gasLimitESDTLocalBurn: IGasLimit;
     gasLimitSetSpecialRole: IGasLimit;
@@ -26,7 +27,7 @@ interface IConfig {
     issueCost: BigNumber.Value;
     esdtContractAddress: IAddress;
 
-    gasLimitToggleBurnRoleGlobally: IGasLimit;
+    shouldWarnAboutUnsettingBurnRoleGlobally: boolean;
 }
 
 interface IBaseArgs {
@@ -197,6 +198,8 @@ export class TokenOperationsFactory {
     }
 
     issueFungible(args: IIssueFungibleArgs): Transaction {
+        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+
         const parts = [
             "issue",
             utf8ToHex(args.tokenName),
@@ -223,7 +226,23 @@ export class TokenOperationsFactory {
         });
     }
 
+    private warnAboutUnsettingBurnRoleGloballyIfAppropriate() {
+        if (!this.config.shouldWarnAboutUnsettingBurnRoleGlobally) {
+            return;
+        }
+
+        console.warn(`
+==========
+IMPORTANT!
+==========
+You are about to issue (register) a new token. 
+By default, this will set the role "ESDTRoleBurnForAll" (globally).
+Once the token is registered, you can unset this role by calling "unsetBurnRoleGlobally" (in a separate transaction).`);
+    }
+
     issueSemiFungible(args: IIssueSemiFungibleArgs): Transaction {
+        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+
         const parts = [
             "issueSemiFungible",
             utf8ToHex(args.tokenName),
@@ -250,6 +269,8 @@ export class TokenOperationsFactory {
     }
 
     issueNonFungible(args: IIssueNonFungibleArgs): Transaction {
+        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+
         const parts = [
             "issueNonFungible",
             utf8ToHex(args.tokenName),
@@ -276,6 +297,8 @@ export class TokenOperationsFactory {
     }
 
     registerMetaESDT(args: IRegisterMetaESDT): Transaction {
+        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+
         const parts = [
             "registerMetaESDT",
             utf8ToHex(args.tokenName),
@@ -303,6 +326,8 @@ export class TokenOperationsFactory {
     }
 
     registerAndSetAllRoles(args: IRegisterAndSetAllRoles): Transaction {
+        this.warnAboutUnsettingBurnRoleGloballyIfAppropriate();
+
         const parts = [
             "registerAndSetAllRoles",
             utf8ToHex(args.tokenName),

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -25,6 +25,8 @@ interface IConfig {
     gasLimitStorePerByte: IGasLimit;
     issueCost: BigNumber.Value;
     esdtContractAddress: IAddress;
+
+    gasLimitToggleBurnRoleGlobally: IGasLimit;
 }
 
 interface IBaseArgs {
@@ -68,6 +70,11 @@ interface IIssueNonFungibleArgs extends IIssueSemiFungibleArgs {
 
 interface IRegisterMetaESDT extends IIssueSemiFungibleArgs {
     numDecimals: number;
+}
+
+interface IToggleBurnRoleGloballyArgs extends IBaseArgs {
+    manager: IAddress;
+    tokenIdentifier: string;
 }
 
 interface IFungibleSetSpecialRoleArgs extends IBaseArgs {
@@ -275,6 +282,40 @@ export class TokenOperationsFactory {
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitIssue,
+            dataParts: parts
+        });
+    }
+
+    setBurnRoleGlobally(args: IToggleBurnRoleGloballyArgs): Transaction {
+        const parts = [
+            "setBurnRoleGlobally",
+            utf8ToHex(args.tokenIdentifier)
+        ];
+
+        return this.createTransaction({
+            sender: args.manager,
+            receiver: this.config.esdtContractAddress,
+            nonce: args.transactionNonce,
+            gasPrice: args.gasPrice,
+            gasLimitHint: args.gasLimit,
+            executionGasLimit: this.config.gasLimitToggleBurnRoleGlobally,
+            dataParts: parts
+        });
+    }
+
+    unsetBurnRoleGlobally(args: IToggleBurnRoleGloballyArgs): Transaction {
+        const parts = [
+            "unsetBurnRoleGlobally",
+            utf8ToHex(args.tokenIdentifier)
+        ];
+
+        return this.createTransaction({
+            sender: args.manager,
+            receiver: this.config.esdtContractAddress,
+            nonce: args.transactionNonce,
+            gasPrice: args.gasPrice,
+            gasLimitHint: args.gasLimit,
+            executionGasLimit: this.config.gasLimitToggleBurnRoleGlobally,
             dataParts: parts
         });
     }

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -235,8 +235,7 @@ export class TokenOperationsFactory {
 ==========
 IMPORTANT!
 ==========
-You are about to issue (register) a new token. 
-By default, this will set the role "ESDTRoleBurnForAll" (globally).
+You are about to issue (register) a new token. This will set the role "ESDTRoleBurnForAll" (globally).
 Once the token is registered, you can unset this role by calling "unsetBurnRoleGlobally" (in a separate transaction).`);
     }
 

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -45,11 +45,19 @@ interface IIssueFungibleArgs extends IBaseArgs {
     canFreeze: boolean;
     canWipe: boolean;
     canPause: boolean;
-    canMint: boolean;
-    canBurn: boolean;
     canChangeOwner: boolean;
     canUpgrade: boolean;
     canAddSpecialRoles: boolean;
+
+    /**
+     * @deprecated (not used anymore)
+     */
+    canMint?: boolean;
+
+    /**
+     * @deprecated (not used anymore)
+     */
+    canBurn?: boolean;
 }
 
 interface IIssueSemiFungibleArgs extends IBaseArgs {
@@ -198,8 +206,6 @@ export class TokenOperationsFactory {
             ...(args.canFreeze ? [utf8ToHex("canFreeze"), this.trueAsHex] : []),
             ...(args.canWipe ? [utf8ToHex("canWipe"), this.trueAsHex] : []),
             ...(args.canPause ? [utf8ToHex("canPause"), this.trueAsHex] : []),
-            ...(args.canMint ? [utf8ToHex("canMint"), this.trueAsHex] : []),
-            ...(args.canBurn ? [utf8ToHex("canBurn"), this.trueAsHex] : []),
             ...(args.canChangeOwner ? [utf8ToHex("canChangeOwner"), this.trueAsHex] : []),
             ...(args.canUpgrade ? [utf8ToHex("canUpgrade"), this.trueAsHex] : []),
             ...(args.canAddSpecialRoles ? [utf8ToHex("canAddSpecialRoles"), this.trueAsHex] : []),

--- a/src/tokenOperations/tokenOperationsFactoryConfig.ts
+++ b/src/tokenOperations/tokenOperationsFactoryConfig.ts
@@ -23,8 +23,6 @@ export class TokenOperationsFactoryConfig {
     issueCost: BigNumber.Value = "50000000000000000";
     esdtContractAddress: IAddress = Address.fromBech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");
 
-    shouldWarnAboutUnsettingBurnRoleGlobally: boolean = true;
-
     constructor(chainID: IChainID) {
         this.chainID = chainID;
     }

--- a/src/tokenOperations/tokenOperationsFactoryConfig.ts
+++ b/src/tokenOperations/tokenOperationsFactoryConfig.ts
@@ -8,6 +8,7 @@ export class TokenOperationsFactoryConfig {
     minGasLimit = 50000;
     gasLimitPerByte = 1500;
     gasLimitIssue: IGasLimit = 60000000;
+    gasLimitToggleBurnRoleGlobally: IGasLimit = 60000000;
     gasLimitESDTLocalMint: IGasLimit = 300000;
     gasLimitESDTLocalBurn: IGasLimit = 300000;
     gasLimitSetSpecialRole: IGasLimit = 60000000;
@@ -22,7 +23,7 @@ export class TokenOperationsFactoryConfig {
     issueCost: BigNumber.Value = "50000000000000000";
     esdtContractAddress: IAddress = Address.fromBech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");
 
-    gasLimitToggleBurnRoleGlobally: IGasLimit = 60000000;
+    shouldWarnAboutUnsettingBurnRoleGlobally: boolean = true;
 
     constructor(chainID: IChainID) {
         this.chainID = chainID;

--- a/src/tokenOperations/tokenOperationsFactoryConfig.ts
+++ b/src/tokenOperations/tokenOperationsFactoryConfig.ts
@@ -22,6 +22,8 @@ export class TokenOperationsFactoryConfig {
     issueCost: BigNumber.Value = "50000000000000000";
     esdtContractAddress: IAddress = Address.fromBech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");
 
+    gasLimitToggleBurnRoleGlobally: IGasLimit = 60000000;
+
     constructor(chainID: IChainID) {
         this.chainID = chainID;
     }

--- a/src/tokenOperations/tokenOperationsOutcomeParser.ts
+++ b/src/tokenOperations/tokenOperationsOutcomeParser.ts
@@ -134,7 +134,12 @@ export class TokenOperationsOutcomeParser {
         return { tokenIdentifier: tokenIdentifier };
     }
 
-    parseToggleBurnRoleGlobally(transaction: ITransactionOnNetwork): IToggleBurnRoleGloballyOutcome {
+    parseSetBurnRoleGlobally(transaction: ITransactionOnNetwork): IToggleBurnRoleGloballyOutcome {
+        this.ensureNoError(transaction);
+        return {};
+    }
+
+    parseUnsetBurnRoleGlobally(transaction: ITransactionOnNetwork): IToggleBurnRoleGloballyOutcome {
         this.ensureNoError(transaction);
         return {};
     }

--- a/src/tokenOperations/tokenOperationsOutcomeParser.ts
+++ b/src/tokenOperations/tokenOperationsOutcomeParser.ts
@@ -37,6 +37,9 @@ export interface IESDTIssueOutcome {
     tokenIdentifier: string;
 }
 
+export interface IToggleBurnRoleGloballyOutcome {
+}
+
 export interface ISetSpecialRoleOutcome {
     userAddress: string;
     tokenIdentifier: string;
@@ -129,6 +132,11 @@ export class TokenOperationsOutcomeParser {
         const event = this.findSingleEventByIdentifier(transaction, "registerMetaESDT");
         const tokenIdentifier = this.extractTokenIdentifier(event);
         return { tokenIdentifier: tokenIdentifier };
+    }
+
+    parseToggleBurnRoleGlobally(transaction: ITransactionOnNetwork): IToggleBurnRoleGloballyOutcome {
+        this.ensureNoError(transaction);
+        return {};
     }
 
     parseSetSpecialRole(transaction: ITransactionOnNetwork): ISetSpecialRoleOutcome {

--- a/src/tokenOperations/tokenOperationsOutcomeParser.ts
+++ b/src/tokenOperations/tokenOperationsOutcomeParser.ts
@@ -37,6 +37,11 @@ export interface IESDTIssueOutcome {
     tokenIdentifier: string;
 }
 
+export interface IRegisterAndSetAllRolesOutcome {
+    tokenIdentifier: string;
+    roles: string[];
+}
+
 export interface IToggleBurnRoleGloballyOutcome {
 }
 
@@ -132,6 +137,18 @@ export class TokenOperationsOutcomeParser {
         const event = this.findSingleEventByIdentifier(transaction, "registerMetaESDT");
         const tokenIdentifier = this.extractTokenIdentifier(event);
         return { tokenIdentifier: tokenIdentifier };
+    }
+
+    parseRegisterAndSetAllRoles(transaction: ITransactionOnNetwork): IRegisterAndSetAllRolesOutcome {
+        this.ensureNoError(transaction);
+
+        const eventRegister = this.findSingleEventByIdentifier(transaction, "registerAndSetAllRoles");
+        const tokenIdentifier = this.extractTokenIdentifier(eventRegister);
+
+        const eventSetRole = this.findSingleEventByIdentifier(transaction, "ESDTSetRole");
+        const roles = eventSetRole.topics.slice(3).map(topic => topic.valueOf().toString());
+
+        return { tokenIdentifier, roles };
     }
 
     parseSetBurnRoleGlobally(transaction: ITransactionOnNetwork): IToggleBurnRoleGloballyOutcome {


### PR DESCRIPTION
 - In `TokenOperationsFactory.ts`, add new functions: `registerAndSetAllRoles`, `unsetBurnRoleGlobally`, `setBurnRoleGlobally`. 
 - Functions that create token-registering transactions will emit a WARN to notify the developer about the existence of `unsetBurnRoleGlobally` - to be called, if desired (as a separate transaction). Developers can disable this warning by passing `shouldWarnAboutUnsettingBurnRoleGlobally = false` in the factory's constructor.