### PR TITLE
add enums type inference in NativeSerializer and fix Enum valueof()

### DIFF
--- a/src/smartcontracts/typesystem/enum.spec.ts
+++ b/src/smartcontracts/typesystem/enum.spec.ts
@@ -4,6 +4,7 @@ import { U8Type, U8Value } from "./numerical";
 import { Field, FieldDefinition } from "./fields";
 import { EnumType, EnumValue, EnumVariantDefinition } from "./enum";
 import { StringType, StringValue } from "./string";
+import BigNumber from "bignumber.js";
 
 describe("test enums", () => {
     it("should get fields", () => {
@@ -40,6 +41,75 @@ describe("test enums", () => {
         assert.deepEqual(orange.getFieldValue("0"), "#FFA500");
         assert.throw(() => green.getFieldValue("3"), errors.ErrMissingFieldOnEnum);
         assert.throw(() => orange.getFieldValue("1"), errors.ErrMissingFieldOnEnum);
+    });
+
+    it("should get valueOf()", () => {
+        // Define variants
+        let greenVariant = new EnumVariantDefinition("Green", 0, [
+            new FieldDefinition("0", "red component", new U8Type()),
+            new FieldDefinition("1", "green component", new U8Type()),
+            new FieldDefinition("2", "blue component", new U8Type()),
+        ]);
+
+        let orangeVariant = new EnumVariantDefinition("Orange", 1, [
+            new FieldDefinition("0", "hex code", new StringType())
+        ]);
+
+        let yellowVariant = new EnumVariantDefinition("Yellow", 2, [
+            new FieldDefinition("red", "red component", new U8Type()),
+            new FieldDefinition("green", "green component", new U8Type()),
+            new FieldDefinition("blue", "blue component", new U8Type()),
+        ]);
+
+        // Define enum type
+        let enumType = new EnumType("Colour", [
+            greenVariant,
+            orangeVariant,
+            yellowVariant
+        ]);
+
+        // Create enum values
+        let green = new EnumValue(enumType, greenVariant, [
+            new Field(new U8Value(0), "0"),
+            new Field(new U8Value(255), "1"),
+            new Field(new U8Value(0), "2")
+        ]);
+
+        let orange = new EnumValue(enumType, orangeVariant, [
+            new Field(new StringValue("#FFA500"), "0")
+        ]);
+
+        let yellow = new EnumValue(enumType, yellowVariant, [
+            new Field(new U8Value(255), "red"),
+            new Field(new U8Value(255), "green"),
+            new Field(new U8Value(0), "blue")
+        ]);
+
+        // Test valueOf()
+        assert.deepEqual(green.valueOf(), {
+            "name": "Green",
+            "fields": [
+                new BigNumber(0),
+                new BigNumber(255),
+                new BigNumber(0)
+            ]
+        });
+
+        assert.deepEqual(orange.valueOf(), {
+            "name": "Orange",
+            "fields": [
+                "#FFA500"
+            ]
+        });
+
+        assert.deepEqual(yellow.valueOf(), {
+            "name": "Yellow",
+            "fields": [
+                new BigNumber(255),
+                new BigNumber(255),
+                new BigNumber(0)
+            ]
+        });
     });
 });
 

--- a/src/smartcontracts/typesystem/enum.ts
+++ b/src/smartcontracts/typesystem/enum.ts
@@ -149,7 +149,7 @@ export class EnumValue extends TypedValue {
     valueOf() {
         let result: any = { name: this.name, fields: [] };
 
-        this.fields.forEach((field) => (result.fields[field.name] = field.value.valueOf()));
+        this.fields.forEach((field, index) => (result.fields[index] = field.value.valueOf()));
 
         return result;
     }


### PR DESCRIPTION
I have implemented type inference for enum types in the NativeSerializer.

- If a number is provided, it will be processed as the discriminant.
- If a string is provided, it will be processed as the name.
- For enums with fields, a JavaScript object needs to be provided in the following format:
`{ name: string; fields: any}`
 The key of each property in the `fields` object must correspond to the name in the `FieldDefinition`.




I have also updated the `valueof()` method of `EnumValue`. When we receive an ABI file from a smart contract built with complex enums, the names of the fields are the same as those in the Rust code. This means they can be either numbers or strings.

This indicates that the following code cannot work correctly with a string as a name:
https://github.com/multiversx/mx-sdk-js-core/blob/30f4fbfcfaf70b5b30213b5ebb3b9cf5feb6dc1a/src/smartcontracts/typesystem/enum.ts#L150-L152

I believe the fields property should be an object rather than an array, but this change would definitely lead to a breaking change. However, I think my fix doesn't break anything by using the index instead of the name itself.