### PR TITLE
Check if isCompleted is undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@multiversx/sdk-network-providers": "1.2.1",
+        "@multiversx/sdk-network-providers-next": "npm:@multiversx/sdk-network-providers@1.6.0-beta.0",
         "@multiversx/sdk-wallet": "3.0.0",
         "@multiversx/sdk-wallet-next": "npm:@multiversx/sdk-wallet@4.0.0",
         "@types/assert": "1.4.6",
@@ -487,6 +488,20 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.2.1.tgz",
       "integrity": "sha512-hRCuoOf9Kh9qArsCPWUrVn45lTWzFloLK0F9f4vNh3WWw4SplfFE/G4TwN8+F35IFMArvTcPibXnRzMb5z48Jw==",
+      "dev": true,
+      "dependencies": {
+        "axios": "0.24.0",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "buffer": "6.0.3",
+        "json-bigint": "1.0.0"
+      }
+    },
+    "node_modules/@multiversx/sdk-network-providers-next": {
+      "name": "@multiversx/sdk-network-providers",
+      "version": "1.6.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.6.0-beta.0.tgz",
+      "integrity": "sha512-BQ51Cj36M3T0hWVpjba2k4SWmD/MYziSop4LFKN4kns6HqwKm3lF6HuKuptSq09HeyTpl6xU4EEkVq0lclX4Kw==",
       "dev": true,
       "dependencies": {
         "axios": "0.24.0",
@@ -4726,6 +4741,19 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.2.1.tgz",
       "integrity": "sha512-hRCuoOf9Kh9qArsCPWUrVn45lTWzFloLK0F9f4vNh3WWw4SplfFE/G4TwN8+F35IFMArvTcPibXnRzMb5z48Jw==",
+      "dev": true,
+      "requires": {
+        "axios": "0.24.0",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "buffer": "6.0.3",
+        "json-bigint": "1.0.0"
+      }
+    },
+    "@multiversx/sdk-network-providers-next": {
+      "version": "npm:@multiversx/sdk-network-providers@1.6.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-network-providers/-/sdk-network-providers-1.6.0-beta.0.tgz",
+      "integrity": "sha512-BQ51Cj36M3T0hWVpjba2k4SWmD/MYziSop4LFKN4kns6HqwKm3lF6HuKuptSq09HeyTpl6xU4EEkVq0lclX4Kw==",
       "dev": true,
       "requires": {
         "axios": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@multiversx/sdk-network-providers": "1.2.1",
+    "@multiversx/sdk-network-providers-next": "npm:@multiversx/sdk-network-providers@1.6.0-beta.0",
     "@multiversx/sdk-wallet": "3.0.0",
     "@multiversx/sdk-wallet-next": "npm:@multiversx/sdk-wallet@4.0.0",
     "@types/assert": "1.4.6",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -325,3 +325,9 @@ export class ErrGasLimitShouldBe0ForInnerTransaction extends Err {
     super("gas limit must be 0 for the inner transaction for relayed v2");
   }
 }
+
+export class ErrIsCompletedFieldIsMissingOnTransaction extends Err {
+  public constructor() {
+    super("The transaction watcher requires the isCompleted property to be defined on the transaction object. Perhaps you've used the sdk-network-provider's getTransaction() and in that case you should also pass `withProcessStatus=true`.")
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -325,12 +325,3 @@ export class ErrGasLimitShouldBe0ForInnerTransaction extends Err {
     super("gas limit must be 0 for the inner transaction for relayed v2");
   }
 }
-
-/**
- * Signals an optional class member is undefined
- */
-export class ErrOptionalClassMemberIsUndefined extends Err {
-  public constructor(message: string) {
-    super(message);
-  }
-}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -325,3 +325,12 @@ export class ErrGasLimitShouldBe0ForInnerTransaction extends Err {
     super("gas limit must be 0 for the inner transaction for relayed v2");
   }
 }
+
+/**
+ * Signals an optional class member is undefined
+ */
+export class ErrOptionalClassMemberIsUndefined extends Err {
+  public constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -328,6 +328,6 @@ export class ErrGasLimitShouldBe0ForInnerTransaction extends Err {
 
 export class ErrIsCompletedFieldIsMissingOnTransaction extends Err {
   public constructor() {
-    super("The transaction watcher requires the isCompleted property to be defined on the transaction object. Perhaps you've used the sdk-network-provider's getTransaction() and in that case you should also pass `withProcessStatus=true`.")
+    super("The transaction watcher requires the `isCompleted` property to be defined on the transaction object. Perhaps you've used the sdk-network-provider's `getTransaction()` and in that case you should also pass `withProcessStatus=true`.")
   }
 }

--- a/src/interfaceOfNetwork.ts
+++ b/src/interfaceOfNetwork.ts
@@ -13,8 +13,8 @@ export interface INetworkConfig {
 }
 
 export interface ITransactionOnNetwork {
-    isCompleted: boolean;
-    
+    isCompleted?: boolean;
+
     hash: string;
     type: string;
     value: string;

--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -1,5 +1,5 @@
 import { AsyncTimer } from "./asyncTimer";
-import { Err, ErrExpectedTransactionEventsNotFound, ErrExpectedTransactionStatusNotReached } from "./errors";
+import { Err, ErrExpectedTransactionEventsNotFound, ErrExpectedTransactionStatusNotReached, ErrIsCompletedFieldIsMissingOnTransaction } from "./errors";
 import { ITransactionFetcher } from "./interface";
 import { ITransactionEvent, ITransactionOnNetwork, ITransactionStatus } from "./interfaceOfNetwork";
 import { Logger } from "./logger";
@@ -71,7 +71,7 @@ export class TransactionWatcher {
     public async awaitCompleted(transaction: ITransaction): Promise<ITransactionOnNetwork> {
         const isCompleted = (transactionOnNetwork: ITransactionOnNetwork) => {
             if (transactionOnNetwork.isCompleted === undefined) {
-                throw new Err("The transaction watcher requires the isCompleted property to be defined on the transaction object. Perhaps you've used the sdk-network-provider's getTransaction() and in that case you should also pass `withProcessStatus=true`.");
+                throw new ErrIsCompletedFieldIsMissingOnTransaction();
             }
             return transactionOnNetwork.isCompleted
         };
@@ -160,6 +160,10 @@ export class TransactionWatcher {
                 }
             } catch (error) {
                 Logger.debug("TransactionWatcher.awaitConditionally(): cannot (yet) fetch data.");
+
+                if (error instanceof ErrIsCompletedFieldIsMissingOnTransaction) {
+                    throw error;
+                }
 
                 if (!(error instanceof Err)) {
                     throw error;

--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -1,5 +1,5 @@
 import { AsyncTimer } from "./asyncTimer";
-import { Err, ErrExpectedTransactionEventsNotFound, ErrExpectedTransactionStatusNotReached, ErrOptionalClassMemberIsUndefined } from "./errors";
+import { Err, ErrExpectedTransactionEventsNotFound, ErrExpectedTransactionStatusNotReached } from "./errors";
 import { ITransactionFetcher } from "./interface";
 import { ITransactionEvent, ITransactionOnNetwork, ITransactionStatus } from "./interfaceOfNetwork";
 import { Logger } from "./logger";
@@ -71,7 +71,7 @@ export class TransactionWatcher {
     public async awaitCompleted(transaction: ITransaction): Promise<ITransactionOnNetwork> {
         const isCompleted = (transactionOnNetwork: ITransactionOnNetwork) => {
             if (transactionOnNetwork.isCompleted === undefined) {
-                throw new ErrOptionalClassMemberIsUndefined("`isCompleted` is undefined. getTransaction() should be called using `withProcessStatus=true`.");
+                throw new Err("The transaction watcher requires the isCompleted property to be defined on the transaction object. Perhaps you've used the sdk-network-provider's getTransaction() and in that case you should also pass `withProcessStatus=true`.");
             }
             return transactionOnNetwork.isCompleted
         };

--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -1,5 +1,5 @@
 import { AsyncTimer } from "./asyncTimer";
-import { Err, ErrExpectedTransactionEventsNotFound, ErrExpectedTransactionStatusNotReached } from "./errors";
+import { Err, ErrExpectedTransactionEventsNotFound, ErrExpectedTransactionStatusNotReached, ErrOptionalClassMemberIsUndefined } from "./errors";
 import { ITransactionFetcher } from "./interface";
 import { ITransactionEvent, ITransactionOnNetwork, ITransactionStatus } from "./interfaceOfNetwork";
 import { Logger } from "./logger";
@@ -69,7 +69,13 @@ export class TransactionWatcher {
       * Waits until the transaction is completely processed.
       */
     public async awaitCompleted(transaction: ITransaction): Promise<ITransactionOnNetwork> {
-        const isCompleted = (transactionOnNetwork: ITransactionOnNetwork) => transactionOnNetwork.isCompleted;
+        const isCompleted = (transactionOnNetwork: ITransactionOnNetwork) => {
+            if (transactionOnNetwork.isCompleted === undefined) {
+                throw new ErrOptionalClassMemberIsUndefined("`isCompleted` is undefined. getTransaction() should be called using `withProcessStatus=true`.");
+            }
+            return transactionOnNetwork.isCompleted
+        };
+
         const doFetch = async () => await this.fetcher.getTransaction(transaction.getHash().hex());
         const errorProvider = () => new ErrExpectedTransactionStatusNotReached();
 


### PR DESCRIPTION
This is done because in the new version of `sdk-network-providers` the `isCompleted` field has become **optional**. Nothing has changed for the `ApiNetworkProvider`, but for the `ProxyNetworkProvider` the `isCompleted` field will only be set if `getTransaction()` is called using `withProcessStatus=true`.

As you may know, the `TransactionWatcher` class needs a `TransactionFetcher` object when initialized. You can use both `ApiNetworkProvider` or `ProxyNetworkProvider` because both respect the interface.

In case you are using the `proxy` provider and you need the `isCompleted` field, a plain object that uses the proxy provider can be passed, defining a `getTransaction()` method that explicitly calls `proxyProvider.getTransaction()` using `withProcessStatus=true`. This can be done as bellow:

```
let provider = new ProxyNetworkProvider("http://localhost:7950", { timeout: 5000 });
let watcher = new TransactionWatcher({
    getTransaction: async (hash: string) => { return await provider.getTransaction(hash, true) }
});
```

Now, the completion checks are more strict, so it takes more time to check if a transaction is completed. The changes have been done in the following PR's:
- https://github.com/multiversx/mx-chain-proxy-go/pull/386
- https://github.com/multiversx/mx-sdk-js-network-providers/pull/41