### PR TITLE
New parameter on "transactionIntentBuilder": "addDataMovementGas"

### DIFF
--- a/src/transactionIntentsFactories/delegationTransactionIntentsFactory.ts
+++ b/src/transactionIntentsFactories/delegationTransactionIntentsFactory.ts
@@ -50,7 +50,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(DELEGATION_MANAGER_SC_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: executionGasLimit,
+            gasLimit: executionGasLimit,
+            addDataMovementGas: true,
             value: options.value
         }).build();
     }
@@ -77,7 +78,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: this.computeExecutionGasLimitForNodesManagement(numNodes)
+            gasLimit: this.computeExecutionGasLimitForNodesManagement(numNodes),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -99,7 +101,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: this.computeExecutionGasLimitForNodesManagement(numNodes)
+            gasLimit: this.computeExecutionGasLimitForNodesManagement(numNodes),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -125,7 +128,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: executionGasLimit
+            gasLimit: executionGasLimit,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -151,7 +155,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: executionGasLimit
+            gasLimit: executionGasLimit,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -177,7 +182,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: executionGasLimit
+            gasLimit: executionGasLimit,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -199,7 +205,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: this.computeExecutionGasLimitForNodesManagement(numNodes)
+            gasLimit: this.computeExecutionGasLimitForNodesManagement(numNodes),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -218,7 +225,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations)
+            gasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -237,7 +245,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations)
+            gasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -255,7 +264,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations)
+            gasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -273,7 +283,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations)
+            gasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -291,7 +302,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations)
+            gasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -309,7 +321,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations)
+            gasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -332,7 +345,8 @@ export class DelegationTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.delegationContract,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations)
+            gasLimit: new BigNumber(this.config.gasLimitDelegationOperations).plus(this.config.additionalGasLimitForDelegationOperations),
+            addDataMovementGas: true
         }).build();
     }
 

--- a/src/transactionIntentsFactories/smartContractTransactionIntentsFactory.spec.ts
+++ b/src/transactionIntentsFactories/smartContractTransactionIntentsFactory.spec.ts
@@ -67,8 +67,7 @@ describe("test smart contract intents factory", function () {
         assert.isDefined(deployIntent.data);
         expect(deployIntent.data!.length).to.be.greaterThan(0);
 
-        const expectedGasLimit = 6000000 + 50000 + 1500 * deployIntent.data!.length;
-        assert.equal(deployIntent.gasLimit.valueOf(), expectedGasLimit);
+        assert.equal(deployIntent.gasLimit.valueOf(), gasLimit);
         assert.equal(deployIntent.value, 0);
 
         assert.deepEqual(deployIntent, abiDeployIntent);
@@ -102,7 +101,7 @@ describe("test smart contract intents factory", function () {
         assert.isDefined(deployIntent.data);
         assert.deepEqual(deployIntent.data, Buffer.from("add@07"));
 
-        assert.equal(deployIntent.gasLimit.valueOf(), 6059000);
+        assert.equal(deployIntent.gasLimit.valueOf(), gasLimit);
         assert.equal(deployIntent.value, 0);
 
         assert.deepEqual(deployIntent, abiDeployIntent);
@@ -135,8 +134,7 @@ describe("test smart contract intents factory", function () {
         assert.isDefined(deployIntent.data);
         assert.isTrue(Buffer.from(deployIntent.data!).toString().startsWith("upgradeContract@"));
 
-        const expectedGasLimit = 6000000 + 50000 + 1500 * deployIntent.data!.length;
-        assert.equal(deployIntent.gasLimit.valueOf(), expectedGasLimit);
+        assert.equal(deployIntent.gasLimit.valueOf(), gasLimit);
         assert.equal(deployIntent.value, 0);
 
         assert.deepEqual(deployIntent, abiDeployIntent);

--- a/src/transactionIntentsFactories/smartContractTransactionIntentsFactory.ts
+++ b/src/transactionIntentsFactories/smartContractTransactionIntentsFactory.ts
@@ -62,7 +62,8 @@ export class SmartContractTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(CONTRACT_DEPLOY_ADDRESS),
             dataParts: parts,
-            executionGasLimit: options.gasLimit
+            gasLimit: options.gasLimit,
+            addDataMovementGas: false
         }).build();
     }
 
@@ -85,7 +86,8 @@ export class SmartContractTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.contractAddress,
             dataParts: parts,
-            executionGasLimit: options.gasLimit
+            gasLimit: options.gasLimit,
+            addDataMovementGas: false
         }).build();
     }
 
@@ -123,7 +125,8 @@ export class SmartContractTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.contract,
             dataParts: parts,
-            executionGasLimit: options.gasLimit
+            gasLimit: options.gasLimit,
+            addDataMovementGas: false
         }).build();
     }
 

--- a/src/transactionIntentsFactories/tokenManagementTransactionIntentsFactory.ts
+++ b/src/transactionIntentsFactories/tokenManagementTransactionIntentsFactory.ts
@@ -72,7 +72,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitIssue,
+            gasLimit: this.config.gasLimitIssue,
+            addDataMovementGas: true,
             value: this.config.issueCost
         }).build();
     }
@@ -109,7 +110,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitIssue,
+            gasLimit: this.config.gasLimitIssue,
+            addDataMovementGas: true,
             value: this.config.issueCost
         }).build();
     }
@@ -146,7 +148,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitIssue,
+            gasLimit: this.config.gasLimitIssue,
+            addDataMovementGas: true,
             value: this.config.issueCost
         }).build();
     }
@@ -185,7 +188,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitIssue,
+            gasLimit: this.config.gasLimitIssue,
+            addDataMovementGas: true,
             value: this.config.issueCost
         }).build();
     }
@@ -212,7 +216,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitIssue,
+            gasLimit: this.config.gasLimitIssue,
+            addDataMovementGas: true,
             value: this.config.issueCost
         }).build();
     }
@@ -231,7 +236,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitToggleBurnRoleGlobally
+            gasLimit: this.config.gasLimitToggleBurnRoleGlobally,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -249,7 +255,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitToggleBurnRoleGlobally
+            gasLimit: this.config.gasLimitToggleBurnRoleGlobally,
+            addDataMovementGas: true,
         }).build();
     }
 
@@ -273,7 +280,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitSetSpecialRole
+            gasLimit: this.config.gasLimitSetSpecialRole,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -301,7 +309,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitSetSpecialRole
+            gasLimit: this.config.gasLimitSetSpecialRole,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -343,7 +352,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: Address.fromBech32(ESDT_CONTRACT_ADDRESS),
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitSetSpecialRole
+            gasLimit: this.config.gasLimitSetSpecialRole,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -377,7 +387,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: new BigNumber(this.config.gasLimitEsdtNftCreate).plus(storageGasLimit)
+            gasLimit: new BigNumber(this.config.gasLimitEsdtNftCreate).plus(storageGasLimit),
+            addDataMovementGas: true
         }).build();
     }
 
@@ -395,7 +406,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitPausing
+            gasLimit: this.config.gasLimitPausing,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -413,7 +425,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitPausing
+            gasLimit: this.config.gasLimitPausing,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -433,7 +446,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitFreezing
+            gasLimit: this.config.gasLimitFreezing,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -453,7 +467,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitFreezing
+            gasLimit: this.config.gasLimitFreezing,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -473,7 +488,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitWiping
+            gasLimit: this.config.gasLimitWiping,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -493,7 +509,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitEsdtLocalMint
+            gasLimit: this.config.gasLimitEsdtLocalMint,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -513,7 +530,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitEsdtLocalBurn
+            gasLimit: this.config.gasLimitEsdtLocalBurn,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -535,7 +553,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitEsdtNftUpdateAttributes
+            gasLimit: this.config.gasLimitEsdtNftUpdateAttributes,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -557,7 +576,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitEsdtNftAddQuantity
+            gasLimit: this.config.gasLimitEsdtNftAddQuantity,
+            addDataMovementGas: true
         }).build();
     }
 
@@ -579,7 +599,8 @@ export class TokenManagementTransactionIntentsFactory {
             sender: options.sender,
             receiver: options.sender,
             dataParts: dataParts,
-            executionGasLimit: this.config.gasLimitEsdtNftBurn
+            gasLimit: this.config.gasLimitEsdtNftBurn,
+            addDataMovementGas: true
         }).build();
     }
 


### PR DESCRIPTION
Allows factories to feed a non-overridable, non-adjustable `gasLimit` parameter to the intent builder. E.g. the smart contract intents factory benefits from this.