### PR TITLE
For constructor of "TokenTransfer", mark "numDecimals" as optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.8.0",
+  "version": "12.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.8.0",
+      "version": "12.8.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.8.0",
+  "version": "12.8.1",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/tokenTransfer.ts
+++ b/src/tokenTransfer.ts
@@ -11,7 +11,7 @@ interface ITokenTransferOptions {
     tokenIdentifier: string;
     nonce: number;
     amountAsBigInteger: BigNumber.Value;
-    numDecimals: number;
+    numDecimals?: number;
 }
 
 export class TokenTransfer {
@@ -29,7 +29,7 @@ export class TokenTransfer {
         this.tokenIdentifier = options.tokenIdentifier;
         this.nonce = options.nonce;
         this.amountAsBigInteger = amount;
-        this.numDecimals = options.numDecimals;
+        this.numDecimals = options.numDecimals || 0;
     }
 
     static egldFromAmount(amount: BigNumber.Value) {

--- a/src/tokenTransfer.ts
+++ b/src/tokenTransfer.ts
@@ -20,7 +20,7 @@ export class TokenTransfer {
     readonly amountAsBigInteger: BigNumber;
     readonly numDecimals: number;
 
-    protected constructor(options: ITokenTransferOptions) {
+    public constructor(options: ITokenTransferOptions) {
         const amount = new BigNumber(options.amountAsBigInteger);
         if (!amount.isInteger() || amount.isNegative()) {
             throw new ErrInvalidArgument(`bad amountAsBigInteger: ${options.amountAsBigInteger}`);


### PR DESCRIPTION
This allows one to create a `TokenTransfer` without having to explicitly set `numDecimals` to zero if token metadata is not known beforehand or if it simply does not matter in the context (not front-end logic etc.).

The developer can choose to directly call the `TokenTransfer` constructor instead of using the specific named constructors `TokenTransfer.fungibleFromBigInteger`, `TokenTransfer.metaEsdtFromBigInteger` etc. - if token metadata and token type are not known beforehand, and fetching the metadata is not desired in the context.

`TokenTransfer`'s constructor is now public (was protected). Thanks @michavie for reporting this :pray: 

This is not a breaking change.