### PR TITLE
Allow "func" to be a simple string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.8.1",
+  "version": "12.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.8.1",
+      "version": "12.9.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.8.1",
+  "version": "12.9.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/smartcontracts/interface.ts
+++ b/src/smartcontracts/interface.ts
@@ -93,6 +93,5 @@ export interface ICodeMetadata {
 }
 
 export interface IContractFunction {
-    name: string;
     toString(): string;
 }

--- a/src/smartcontracts/transactionPayloadBuilders.ts
+++ b/src/smartcontracts/transactionPayloadBuilders.ts
@@ -154,7 +154,7 @@ export class ContractCallPayloadBuilder {
     build(): TransactionPayload {
         guardValueIsSet("calledFunction", this.contractFunction);
 
-        let data = this.contractFunction!.name;
+        let data = this.contractFunction!.toString();
         data = appendArgumentsToString(data, this.arguments);
 
         return new TransactionPayload(data);

--- a/src/testutils/mockProvider.ts
+++ b/src/testutils/mockProvider.ts
@@ -58,7 +58,7 @@ export class MockProvider {
     }
 
     mockQueryContractOnFunction(functionName: string, response: IContractQueryResponse) {
-        let predicate = (query: Query) => query.func.name == functionName;
+        let predicate = (query: Query) => query.func.toString() == functionName;
         this.queryContractResponders.push(new QueryContractResponder(predicate, response));
     }
 


### PR DESCRIPTION
Practically, this is not a breaking change.

```
// Before
tx = contract.call({
    ...
    func: new ContractFunction("add")
    ...
});

// Now (both are supported)
tx = contract.call({
    ...
    func: "add"
    ...
});
```

`IContractFunction` interface is now less restrictive.