### PR TITLE
Handle "events" in abi registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MultiversX SDK for JavaScript and TypeScript (written in TypeScript).
 
 ## Documentation
 
- - [Cookbook](https://docs.multiversx.com/sdk-and-tools/erdjs/erdjs-cookbook/)
+ - [Cookbook](https://docs.multiversx.com/sdk-and-tools/sdk-js/sdk-js-cookbook/)
 
 ## Distribution
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.12.0",
+  "version": "12.13.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.12.0",
+      "version": "12.13.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.13.0",
+  "version": "12.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.13.0",
+      "version": "12.14.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.12.0",
+  "version": "12.13.0-beta.1",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.13.0",
+  "version": "12.14.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/interfaceOfNetwork.ts
+++ b/src/interfaceOfNetwork.ts
@@ -66,7 +66,15 @@ export interface ITransactionLogs {
     events: ITransactionEvent[];
 
     findSingleOrNoneEvent(identifier: string, predicate?: (event: ITransactionEvent) => boolean): ITransactionEvent | undefined;
+
+    /**
+     * @deprecated Will be removed from the interface (with no replacement). Not used in "sdk-core".
+     */
     findFirstOrNoneEvent(identifier: string, predicate?: (event: ITransactionEvent) => boolean): ITransactionEvent | undefined;
+
+    /**
+     * @deprecated Will be removed from the interface (with no replacement). Not used in "sdk-core".
+     */
     findEvents(identifier: string, predicate?: (event: ITransactionEvent) => boolean): ITransactionEvent[];
 }
 

--- a/src/interfaceOfNetwork.ts
+++ b/src/interfaceOfNetwork.ts
@@ -74,7 +74,12 @@ export interface ITransactionEvent {
     readonly address: IAddress;
     readonly identifier: string;
     readonly topics: ITransactionEventTopic[];
+
+    /**
+     * @deprecated Use dataPayload instead.
+     */
     readonly data: string;
+    readonly dataPayload?: { valueOf(): Uint8Array };
 
     findFirstOrNoneTopic(predicate: (topic: ITransactionEventTopic) => boolean): ITransactionEventTopic | undefined;
     getLastTopic(): ITransactionEventTopic;

--- a/src/interfaceOfNetwork.ts
+++ b/src/interfaceOfNetwork.ts
@@ -74,12 +74,7 @@ export interface ITransactionEvent {
     readonly address: IAddress;
     readonly identifier: string;
     readonly topics: ITransactionEventTopic[];
-
-    /**
-     * @deprecated Use dataPayload instead.
-     */
     readonly data: string;
-    readonly dataPayload?: { valueOf(): Uint8Array };
 
     findFirstOrNoneTopic(predicate: (topic: ITransactionEventTopic) => boolean): ITransactionEventTopic | undefined;
     getLastTopic(): ITransactionEventTopic;

--- a/src/smartcontracts/argSerializer.ts
+++ b/src/smartcontracts/argSerializer.ts
@@ -1,6 +1,6 @@
 import { ARGUMENTS_SEPARATOR } from "../constants";
 import { BinaryCodec } from "./codec";
-import { EndpointParameterDefinition, Type, TypedValue, U32Type, U32Value } from "./typesystem";
+import { Type, TypedValue, U32Type, U32Value } from "./typesystem";
 import { OptionalType, OptionalValue } from "./typesystem/algebraic";
 import { CompositeType, CompositeValue } from "./typesystem/composite";
 import { VariadicType, VariadicValue } from "./typesystem/variadic";
@@ -13,6 +13,10 @@ interface IArgSerializerOptions {
 interface ICodec {
     decodeTopLevel(buffer: Buffer, type: Type): TypedValue;
     encodeTopLevel(typedValue: TypedValue): Buffer;
+}
+
+interface IParameterDefinition {
+    type: Type;
 }
 
 // TODO: perhaps move default construction options to a factory (ArgSerializerFactory), instead of referencing them in the constructor
@@ -32,7 +36,7 @@ export class ArgSerializer {
     /**
      * Reads typed values from an arguments string (e.g. aa@bb@@cc), given parameter definitions.
      */
-    stringToValues(joinedString: string, parameters: EndpointParameterDefinition[]): TypedValue[] {
+    stringToValues(joinedString: string, parameters: IParameterDefinition[]): TypedValue[] {
         let buffers = this.stringToBuffers(joinedString);
         let values = this.buffersToValues(buffers, parameters);
         return values;
@@ -49,7 +53,7 @@ export class ArgSerializer {
     /**
      * Decodes a set of buffers into a set of typed values, given parameter definitions.
      */
-    buffersToValues(buffers: Buffer[], parameters: EndpointParameterDefinition[]): TypedValue[] {
+    buffersToValues(buffers: Buffer[], parameters: IParameterDefinition[]): TypedValue[] {
         // TODO: Refactor, split (function is quite complex).
         const self = this;
 

--- a/src/smartcontracts/argSerializer.ts
+++ b/src/smartcontracts/argSerializer.ts
@@ -21,7 +21,7 @@ interface IParameterDefinition {
 
 // TODO: perhaps move default construction options to a factory (ArgSerializerFactory), instead of referencing them in the constructor
 // (postpone as much as possible, breaking change)
-const defaultArgSerializerrOptions: IArgSerializerOptions = {
+const defaultArgSerializerOptions: IArgSerializerOptions = {
     codec: new BinaryCodec()
 };
 
@@ -29,7 +29,7 @@ export class ArgSerializer {
     codec: ICodec;
 
     constructor(options?: IArgSerializerOptions) {
-        options = { ...defaultArgSerializerrOptions, ...options };
+        options = { ...defaultArgSerializerOptions, ...options };
         this.codec = options.codec;
     }
 

--- a/src/smartcontracts/resultsParser.ts
+++ b/src/smartcontracts/resultsParser.ts
@@ -28,6 +28,7 @@ interface IParameterDefinition {
 }
 
 interface IEventInputDefinition {
+    name: string;
     type: Type;
     indexed: boolean;
 }
@@ -326,10 +327,8 @@ export class ResultsParser {
         return { returnCode, returnDataParts };
     }
 
-    parseEvent(transactionEvent: ITransactionEvent, eventDefinition: { inputs: IEventInputDefinition[] }): {
-        topics: TypedValue[],
-        dataParts: TypedValue[]
-    } {
+    parseEvent(transactionEvent: ITransactionEvent, eventDefinition: { inputs: IEventInputDefinition[] }): any {
+        const result: any = {};
         const topics = transactionEvent.topics.map(topic => Buffer.from(topic.hex(), "hex"));
         const data = transactionEvent.dataPayload?.valueOf() || Buffer.from([]);
         const dataHex = data.toString("hex");
@@ -341,9 +340,14 @@ export class ResultsParser {
         const decodedTopics = this.argsSerializer.buffersToValues(topics.slice(1), indexedInputs);
         const decodedDataParts = this.argsSerializer.stringToValues(dataHex, nonIndexedInputs);
 
-        return {
-            topics: decodedTopics,
-            dataParts: decodedDataParts
-        };
+        for (let i = 0; i < indexedInputs.length; i++) {
+            result[indexedInputs[i].name] = decodedTopics[i].valueOf();
+        }
+
+        for (let i = 0; i < nonIndexedInputs.length; i++) {
+            result[nonIndexedInputs[i].name] = decodedDataParts[i].valueOf();
+        }
+
+        return result;
     }
 }

--- a/src/smartcontracts/typesystem/abiRegistry.spec.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.spec.ts
@@ -140,4 +140,20 @@ describe("test abi registry", () => {
         assert.deepEqual(registry.getEndpoint("bar").output[0].type, new VariadicType(new U32Type(), true));
         assert.deepEqual(registry.getEndpoint("bar").output[1].type, new VariadicType(new BytesType(), true));
     });
+
+    it("should load ABI wih events", async () => {
+        const registry = await loadAbiRegistry("src/testdata/esdt-safe.abi.json");
+
+        assert.lengthOf(registry.events, 8);
+
+        const depositEvent = registry.getEvent("deposit");
+        assert.deepEqual(depositEvent.inputs[0].type, new AddressType());
+        assert.deepEqual(depositEvent.inputs[1].type, new ListType(registry.getCustomType("EsdtTokenPayment")));
+        assert.deepEqual(depositEvent.inputs[2].type, registry.getCustomType("DepositEvent"));
+
+        const setStatusEvent = registry.getEvent("setStatusEvent");
+        assert.deepEqual(setStatusEvent.inputs[0].type, new U64Type());
+        assert.deepEqual(setStatusEvent.inputs[1].type, new U64Type());
+        assert.deepEqual(setStatusEvent.inputs[2].type, registry.getCustomType("TransactionStatus"));
+    });
 });

--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -2,6 +2,7 @@ import * as errors from "../../errors";
 import { guardValueIsSetWithMessage } from "../../utils";
 import { EndpointDefinition, EndpointParameterDefinition } from "./endpoint";
 import { EnumType } from "./enum";
+import { EventDefinition, EventTopicDefinition } from "./event";
 import { StructType } from "./struct";
 import { TypeMapper } from "./typeMapper";
 import { CustomType } from "./types";
@@ -13,17 +14,20 @@ export class AbiRegistry {
     readonly constructorDefinition: EndpointDefinition;
     readonly endpoints: EndpointDefinition[] = [];
     readonly customTypes: CustomType[] = [];
+    readonly events: EventDefinition[] = [];
 
     private constructor(options: {
         name: string;
         constructorDefinition: EndpointDefinition;
         endpoints: EndpointDefinition[];
         customTypes: CustomType[],
+        events?: EventDefinition[]
     }) {
         this.name = options.name;
         this.constructorDefinition = options.constructorDefinition;
         this.endpoints = options.endpoints;
         this.customTypes = options.customTypes;
+        this.events = options.events || [];
     }
 
     static create(options: {
@@ -31,11 +35,13 @@ export class AbiRegistry {
         constructor?: any,
         endpoints?: any[];
         types?: Record<string, any>
+        events?: any[]
     }): AbiRegistry {
         const name = options.name || interfaceNamePlaceholder;
         const constructor = options.constructor || {};
         const endpoints = options.endpoints || [];
         const types = options.types || {};
+        const events = options.events || [];
 
         // Load arbitrary input parameters into properly-defined objects (e.g. EndpointDefinition and CustomType).
         const constructorDefinition = EndpointDefinition.fromJSON({ name: "constructor", ...constructor });
@@ -54,15 +60,24 @@ export class AbiRegistry {
             }
         }
 
+        const eventDefinitions = events.map(item => EventDefinition.fromJSON(item));
+
         const registry = new AbiRegistry({
             name: name,
             constructorDefinition: constructorDefinition,
             endpoints: endpointDefinitions,
             customTypes: customTypes,
+            events: eventDefinitions
         });
 
         const remappedRegistry = registry.remapToKnownTypes();
         return remappedRegistry;
+    }
+
+    getCustomType(name: string): CustomType {
+        const result = this.customTypes.find((e) => e.getName() == name);
+        guardValueIsSetWithMessage(`custom type [${name}] not found`, result);
+        return result!;
     }
 
     getStruct(name: string): StructType {
@@ -92,6 +107,12 @@ export class AbiRegistry {
     getEndpoint(name: string): EndpointDefinition {
         const result = this.endpoints.find((e) => e.name == name);
         guardValueIsSetWithMessage(`endpoint [${name}] not found`, result);
+        return result!;
+    }
+
+    getEvent(name: string): EventDefinition {
+        const result = this.events.find((e) => e.identifier == name);
+        guardValueIsSetWithMessage(`event [${name}] not found`, result);
         return result!;
     }
 
@@ -129,12 +150,15 @@ export class AbiRegistry {
             newEndpoints.push(mapEndpoint(endpoint, mapper));
         }
 
+        const newEvents: EventDefinition[] = this.events.map((event) => mapEvent(event, mapper));
+
         // Now return the new registry, with all types remapped to known types
         const newRegistry = new AbiRegistry({
             name: this.name,
             constructorDefinition: newConstructor,
             endpoints: newEndpoints,
             customTypes: newCustomTypes,
+            events: newEvents
         });
 
         return newRegistry;
@@ -171,4 +195,12 @@ function mapEndpoint(endpoint: EndpointDefinition, mapper: TypeMapper): Endpoint
     );
 
     return new EndpointDefinition(endpoint.name, newInput, newOutput, endpoint.modifiers);
+}
+
+function mapEvent(event: EventDefinition, mapper: TypeMapper): EventDefinition {
+    const newInputs = event.inputs.map(
+        (e) => new EventTopicDefinition(e.name, mapper.mapType(e.type))
+    );
+
+    return new EventDefinition(event.identifier, newInputs);
 }

--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -199,7 +199,11 @@ function mapEndpoint(endpoint: EndpointDefinition, mapper: TypeMapper): Endpoint
 
 function mapEvent(event: EventDefinition, mapper: TypeMapper): EventDefinition {
     const newInputs = event.inputs.map(
-        (e) => new EventTopicDefinition(e.name, mapper.mapType(e.type))
+        (e) => new EventTopicDefinition({
+            name: e.name,
+            type: mapper.mapType(e.type),
+            indexed: e.indexed
+        })
     );
 
     return new EventDefinition(event.identifier, newInputs);

--- a/src/smartcontracts/typesystem/event.ts
+++ b/src/smartcontracts/typesystem/event.ts
@@ -1,0 +1,40 @@
+import { TypeExpressionParser } from "./typeExpressionParser";
+import { Type } from "./types";
+
+const NamePlaceholder = "?";
+
+export class EventDefinition {
+    readonly identifier: string;
+    readonly inputs: EventTopicDefinition[] = [];
+
+    constructor(identifier: string, inputs: EventTopicDefinition[]) {
+        this.identifier = identifier;
+        this.inputs = inputs || [];
+    }
+
+    static fromJSON(json: {
+        identifier: string,
+        inputs: any[]
+    }): EventDefinition {
+        json.identifier = json.identifier == null ? NamePlaceholder : json.identifier;
+        json.inputs = json.inputs || [];
+
+        const inputs = json.inputs.map(param => EventTopicDefinition.fromJSON(param));
+        return new EventDefinition(json.identifier, inputs);
+    }
+}
+
+export class EventTopicDefinition {
+    readonly name: string;
+    readonly type: Type;
+
+    constructor(name: string, type: Type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    static fromJSON(json: { name?: string, type: string }): EventTopicDefinition {
+        let parsedType = new TypeExpressionParser().parse(json.type);
+        return new EventTopicDefinition(json.name || NamePlaceholder, parsedType);
+    }
+}

--- a/src/smartcontracts/typesystem/event.ts
+++ b/src/smartcontracts/typesystem/event.ts
@@ -27,14 +27,21 @@ export class EventDefinition {
 export class EventTopicDefinition {
     readonly name: string;
     readonly type: Type;
+    readonly indexed: boolean;
 
-    constructor(name: string, type: Type) {
-        this.name = name;
-        this.type = type;
+    constructor(options: { name: string, type: Type, indexed: boolean }) {
+        this.name = options.name;
+        this.type = options.type;
+        this.indexed = options.indexed;
     }
 
-    static fromJSON(json: { name?: string, type: string }): EventTopicDefinition {
-        let parsedType = new TypeExpressionParser().parse(json.type);
-        return new EventTopicDefinition(json.name || NamePlaceholder, parsedType);
+    static fromJSON(json: { name?: string, type: string, indexed: boolean }): EventTopicDefinition {
+        const parsedType = new TypeExpressionParser().parse(json.type);
+
+        return new EventTopicDefinition({
+            name: json.name || NamePlaceholder,
+            type: parsedType,
+            indexed: json.indexed
+        });
     }
 }

--- a/src/testdata/esdt-safe.abi.json
+++ b/src/testdata/esdt-safe.abi.json
@@ -1,0 +1,725 @@
+{
+    "buildInfo": {
+        "rustc": {
+            "version": "1.75.0-nightly",
+            "commitHash": "42b1224e9eb37177f608d3f6a6f2be2ee13902e4",
+            "commitDate": "2023-10-15",
+            "channel": "Nightly",
+            "short": "rustc 1.75.0-nightly (42b1224e9 2023-10-15)"
+        },
+        "contractCrate": {
+            "name": "esdt-safe",
+            "version": "0.0.0"
+        },
+        "framework": {
+            "name": "multiversx-sc",
+            "version": "0.43.5"
+        }
+    },
+    "name": "EsdtSafe",
+    "constructor": {
+        "inputs": [
+            {
+                "name": "min_valid_signers",
+                "type": "u32"
+            },
+            {
+                "name": "signers",
+                "type": "variadic<Address>",
+                "multi_arg": true
+            }
+        ],
+        "outputs": []
+    },
+    "endpoints": [
+        {
+            "name": "upgrade",
+            "mutability": "mutable",
+            "inputs": [],
+            "outputs": []
+        },
+        {
+            "docs": [
+                "Create an Elrond -> Sovereign transaction."
+            ],
+            "name": "deposit",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "*"
+            ],
+            "inputs": [
+                {
+                    "name": "to",
+                    "type": "Address"
+                },
+                {
+                    "name": "opt_transfer_data",
+                    "type": "optional<TransferData>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "docs": [
+                "Claim funds for failed Elrond -> Sovereign transactions.",
+                "These are not sent automatically to prevent the contract getting stuck.",
+                "For example, if the receiver is a SC, a frozen account, etc."
+            ],
+            "name": "claimRefund",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "token_id",
+                    "type": "TokenIdentifier"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "List<EsdtTokenPayment>"
+                }
+            ]
+        },
+        {
+            "docs": [
+                "Sets the statuses for the transactions, after they were executed on the Sovereign side.",
+                "",
+                "Only TransactionStatus::Executed (3) and TransactionStatus::Rejected (4) values are allowed.",
+                "Number of provided statuses must be equal to number of transactions in the batch."
+            ],
+            "name": "setTransactionBatchStatus",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64"
+                },
+                {
+                    "name": "signature",
+                    "type": "array48<u8>"
+                },
+                {
+                    "name": "tx_statuses",
+                    "type": "variadic<TransactionStatus>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "setMinValidSigners",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "new_value",
+                    "type": "u32"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "addSigners",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "signers",
+                    "type": "variadic<Address>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "removeSigners",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "signers",
+                    "type": "variadic<Address>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "registerToken",
+            "mutability": "mutable",
+            "payableInTokens": [
+                "EGLD"
+            ],
+            "inputs": [
+                {
+                    "name": "sov_token_id",
+                    "type": "TokenIdentifier"
+                },
+                {
+                    "name": "token_type",
+                    "type": "EsdtTokenType"
+                },
+                {
+                    "name": "token_display_name",
+                    "type": "bytes"
+                },
+                {
+                    "name": "token_ticker",
+                    "type": "bytes"
+                },
+                {
+                    "name": "num_decimals",
+                    "type": "u32"
+                },
+                {
+                    "name": "bls_multisig",
+                    "type": "array48<u8>"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "clearRegisteredToken",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "sov_token_id",
+                    "type": "TokenIdentifier"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "batchTransferEsdtToken",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64"
+                },
+                {
+                    "name": "signature",
+                    "type": "array48<u8>"
+                },
+                {
+                    "name": "transfers",
+                    "type": "variadic<Transaction>",
+                    "multi_arg": true
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "setMaxTxBatchSize",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "new_max_tx_batch_size",
+                    "type": "u32"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "setMaxTxBatchBlockDuration",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "new_max_tx_batch_block_duration",
+                    "type": "u64"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "getCurrentTxBatch",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "optional<multi<u64,variadic<multi<u64,u64,Address,Address,List<EsdtTokenPayment>,List<StolenFromFrameworkEsdtTokenData>,Option<TransferData>>>>>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "getFirstBatchAnyStatus",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "optional<multi<u64,variadic<multi<u64,u64,Address,Address,List<EsdtTokenPayment>,List<StolenFromFrameworkEsdtTokenData>,Option<TransferData>>>>>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "getBatch",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "optional<multi<u64,variadic<multi<u64,u64,Address,Address,List<EsdtTokenPayment>,List<StolenFromFrameworkEsdtTokenData>,Option<TransferData>>>>>",
+                    "multi_result": true
+                }
+            ]
+        },
+        {
+            "name": "getBatchStatus",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "BatchStatus"
+                }
+            ]
+        },
+        {
+            "name": "getFirstBatchId",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "getLastBatchId",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "setMaxBridgedAmount",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "token_id",
+                    "type": "TokenIdentifier"
+                },
+                {
+                    "name": "max_amount",
+                    "type": "BigUint"
+                }
+            ],
+            "outputs": []
+        },
+        {
+            "name": "getMaxBridgedAmount",
+            "mutability": "readonly",
+            "inputs": [
+                {
+                    "name": "token_id",
+                    "type": "TokenIdentifier"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "BigUint"
+                }
+            ]
+        },
+        {
+            "name": "pause",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [],
+            "outputs": []
+        },
+        {
+            "name": "unpause",
+            "onlyOwner": true,
+            "mutability": "mutable",
+            "inputs": [],
+            "outputs": []
+        },
+        {
+            "name": "isPaused",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "bool"
+                }
+            ]
+        }
+    ],
+    "promisesCallbackNames": [
+        "transfer_callback"
+    ],
+    "events": [
+        {
+            "identifier": "deposit",
+            "inputs": [
+                {
+                    "name": "dest_address",
+                    "type": "Address",
+                    "indexed": true
+                },
+                {
+                    "name": "tokens",
+                    "type": "List<EsdtTokenPayment>",
+                    "indexed": true
+                },
+                {
+                    "name": "event_data",
+                    "type": "DepositEvent"
+                }
+            ]
+        },
+        {
+            "identifier": "setStatusEvent",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx_status",
+                    "type": "TransactionStatus",
+                    "indexed": true
+                }
+            ]
+        },
+        {
+            "identifier": "addRefundTransactionEvent",
+            "inputs": [
+                {
+                    "name": "tx_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "original_tx_id",
+                    "type": "u64",
+                    "indexed": true
+                }
+            ]
+        },
+        {
+            "identifier": "transferPerformedEvent",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx",
+                    "type": "Transaction"
+                }
+            ]
+        },
+        {
+            "identifier": "transferFailedInvalidToken",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx_id",
+                    "type": "u64",
+                    "indexed": true
+                }
+            ]
+        },
+        {
+            "identifier": "transferFailedFrozenDestinationAccount",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx_id",
+                    "type": "u64",
+                    "indexed": true
+                }
+            ]
+        },
+        {
+            "identifier": "transferOverMaxAmount",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx_id",
+                    "type": "u64",
+                    "indexed": true
+                }
+            ]
+        },
+        {
+            "identifier": "transferFailedExecutionFailed",
+            "inputs": [
+                {
+                    "name": "batch_id",
+                    "type": "u64",
+                    "indexed": true
+                },
+                {
+                    "name": "tx_id",
+                    "type": "u64",
+                    "indexed": true
+                }
+            ]
+        }
+    ],
+    "hasCallback": true,
+    "types": {
+        "BatchStatus": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "AlreadyProcessed",
+                    "discriminant": 0
+                },
+                {
+                    "name": "Empty",
+                    "discriminant": 1
+                },
+                {
+                    "name": "PartiallyFull",
+                    "discriminant": 2,
+                    "fields": [
+                        {
+                            "name": "end_block_nonce",
+                            "type": "u64"
+                        },
+                        {
+                            "name": "tx_ids",
+                            "type": "List<u64>"
+                        }
+                    ]
+                },
+                {
+                    "name": "Full",
+                    "discriminant": 3
+                },
+                {
+                    "name": "WaitingForSignatures",
+                    "discriminant": 4
+                }
+            ]
+        },
+        "DepositEvent": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "tx_nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "opt_function",
+                    "type": "Option<bytes>"
+                },
+                {
+                    "name": "opt_arguments",
+                    "type": "Option<List<bytes>>"
+                },
+                {
+                    "name": "opt_gas_limit",
+                    "type": "Option<u64>"
+                }
+            ]
+        },
+        "EsdtTokenPayment": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "token_identifier",
+                    "type": "TokenIdentifier"
+                },
+                {
+                    "name": "token_nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount",
+                    "type": "BigUint"
+                }
+            ]
+        },
+        "EsdtTokenType": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "Fungible",
+                    "discriminant": 0
+                },
+                {
+                    "name": "NonFungible",
+                    "discriminant": 1
+                },
+                {
+                    "name": "SemiFungible",
+                    "discriminant": 2
+                },
+                {
+                    "name": "Meta",
+                    "discriminant": 3
+                },
+                {
+                    "name": "Invalid",
+                    "discriminant": 4
+                }
+            ]
+        },
+        "StolenFromFrameworkEsdtTokenData": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "token_type",
+                    "type": "EsdtTokenType"
+                },
+                {
+                    "name": "amount",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "frozen",
+                    "type": "bool"
+                },
+                {
+                    "name": "hash",
+                    "type": "bytes"
+                },
+                {
+                    "name": "name",
+                    "type": "bytes"
+                },
+                {
+                    "name": "attributes",
+                    "type": "bytes"
+                },
+                {
+                    "name": "creator",
+                    "type": "Address"
+                },
+                {
+                    "name": "royalties",
+                    "type": "BigUint"
+                },
+                {
+                    "name": "uris",
+                    "type": "List<bytes>"
+                }
+            ]
+        },
+        "Transaction": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "block_nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "nonce",
+                    "type": "u64"
+                },
+                {
+                    "name": "from",
+                    "type": "Address"
+                },
+                {
+                    "name": "to",
+                    "type": "Address"
+                },
+                {
+                    "name": "tokens",
+                    "type": "List<EsdtTokenPayment>"
+                },
+                {
+                    "name": "token_data",
+                    "type": "List<StolenFromFrameworkEsdtTokenData>"
+                },
+                {
+                    "name": "opt_transfer_data",
+                    "type": "Option<TransferData>"
+                },
+                {
+                    "name": "is_refund_tx",
+                    "type": "bool"
+                }
+            ]
+        },
+        "TransactionStatus": {
+            "type": "enum",
+            "variants": [
+                {
+                    "name": "None",
+                    "discriminant": 0
+                },
+                {
+                    "name": "Pending",
+                    "discriminant": 1
+                },
+                {
+                    "name": "InProgress",
+                    "discriminant": 2
+                },
+                {
+                    "name": "Executed",
+                    "discriminant": 3
+                },
+                {
+                    "name": "Rejected",
+                    "discriminant": 4
+                }
+            ]
+        },
+        "TransferData": {
+            "type": "struct",
+            "fields": [
+                {
+                    "name": "gas_limit",
+                    "type": "u64"
+                },
+                {
+                    "name": "function",
+                    "type": "bytes"
+                },
+                {
+                    "name": "args",
+                    "type": "List<bytes>"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Implement `ResultsParser.parseEvent()`.

Usage example:

```
const eventDefinition = abiRegistry.getEvent("deposit");

// Can be taken from a "TransactionOnNetwork" object
const event = new TransactionEvent({
    identifier: "deposit",
    topics: [
        new TransactionEventTopic("ZGVwb3NpdA=="),
        new TransactionEventTopic("cmzC1LRt1r10pMhNAnFb+FyudjGMq4G8CefCYdQUmmc="),
        new TransactionEventTopic("AAAADFdFR0xELTAxZTQ5ZAAAAAAAAAAAAAAAAWQ="),
    ],
    dataPayload: new TransactionEventData(Buffer.from("AAAAAAAAA9sAAAA=", "base64"))
});

const bundle = parser.parseEvent(event, eventDefinition);
console.log(bundle);
```

A few **examples** will be added in this PR:
https://github.com/multiversx/mx-sdk-js-examples/pull/28

Related PR on network-providers (required to decode events for Sirius / Node v1.6.0 - as of 13th November 2023, on Testnet):
https://github.com/multiversx/mx-sdk-js-network-providers/pull/49