### PR TITLE
Fix applySignature(). Handle buffers in a better way

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.12.0",
+  "version": "12.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.12.0",
+      "version": "12.13.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.12.0",
+  "version": "12.13.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/signableMessage.ts
+++ b/src/signableMessage.ts
@@ -1,5 +1,6 @@
 import { Address } from "./address";
 import { ISignature } from "./interface";
+import { interpretSignatureAsBuffer } from "./signature";
 const createKeccakHash = require("keccak");
 
 export const MESSAGE_PREFIX = "\x17Elrond Signed Message:\n";
@@ -57,11 +58,7 @@ export class SignableMessage {
   }
 
   applySignature(signature: ISignature | Buffer) {
-    if (signature instanceof Buffer) {
-      this.signature = signature;
-    } else {
-      this.signature = Buffer.from(signature.hex(), "hex");
-    }
+    this.signature = interpretSignatureAsBuffer(signature);
   }
 
   getMessageSize(): Buffer {

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -1,4 +1,4 @@
-import  * as errors from "./errors";
+import * as errors from "./errors";
 
 
 const SIGNATURE_LENGTH = 64;
@@ -57,4 +57,14 @@ export class Signature {
     hex() {
         return this.valueHex;
     }
+}
+
+export function interpretSignatureAsBuffer(signature: { hex(): string; } | Uint8Array): Buffer {
+    if (ArrayBuffer.isView(signature)) {
+        return Buffer.from(signature);
+    } else if ((<any>signature).hex != null) {
+        return Buffer.from(signature.hex(), "hex");
+    }
+
+    throw new Error(`Object cannot be interpreted as a signature: ${signature}`);
 }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -8,7 +8,7 @@ import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, IPlainTransactionObje
 import { INetworkConfig } from "./interfaceOfNetwork";
 import { TransactionOptions, TransactionVersion } from "./networkParams";
 import { ProtoSerializer } from "./proto";
-import { Signature } from "./signature";
+import { Signature, interpretSignatureAsBuffer } from "./signature";
 import { TransactionPayload } from "./transactionPayload";
 import { guardNotEmpty } from "./utils";
 
@@ -372,18 +372,8 @@ export class Transaction {
    * @param signature The signature, as computed by a signer.
    */
   applySignature(signature: ISignature | Uint8Array) {
-    this.signature = this.interpretSignatureAsBuffer(signature);
+    this.signature = interpretSignatureAsBuffer(signature);
     this.hash = TransactionHash.compute(this);
-  }
-
-  private interpretSignatureAsBuffer(signature: ISignature | Uint8Array): Buffer {
-    if (ArrayBuffer.isView(signature)) {
-      return Buffer.from(signature);
-    } else if ((<any>signature).hex != null) {
-      return Buffer.from(signature.hex(), "hex");
-    }
-
-    throw new Error(`Object cannot be interpreted as a signature: ${signature}`);
   }
 
   /**
@@ -392,7 +382,7 @@ export class Transaction {
    * @param guardianSignature The signature, as computed by a signer.
    */
   applyGuardianSignature(guardianSignature: ISignature | Uint8Array) {
-    this.guardianSignature = this.interpretSignatureAsBuffer(guardianSignature);
+    this.guardianSignature = interpretSignatureAsBuffer(guardianSignature);
     this.hash = TransactionHash.compute(this);
   }
 


### PR DESCRIPTION
 - Apply the same logic for both messages and transactions.
 - Move `interpretSignatureAsBuffer` to `signature.ts`.