### PR TITLE
Removed old canMint and canBurn arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.15.0",
+  "version": "12.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "12.15.0",
+      "version": "12.16.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "12.15.0",
+  "version": "12.16.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
+++ b/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
@@ -43,7 +43,7 @@ describe("test factory on testnet", function () {
             tokenTicker: "TEST",
             tokenType: "FNG",
             numDecimals: 2,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -64,7 +64,7 @@ describe("test factory on testnet", function () {
             tokenTicker: "TEST",
             tokenType: "NFT",
             numDecimals: 0,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -87,7 +87,7 @@ describe("test factory on testnet", function () {
             tokenTicker: "TEST",
             tokenType: "SFT",
             numDecimals: 0,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -109,7 +109,7 @@ describe("test factory on testnet", function () {
             tokenTicker: "TEST",
             tokenType: "META",
             numDecimals: 2,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -135,12 +135,10 @@ describe("test factory on testnet", function () {
             canFreeze: true,
             canWipe: true,
             canPause: true,
-            canMint: true,
-            canBurn: true,
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -152,7 +150,7 @@ describe("test factory on testnet", function () {
         const tx2 = factory.unsetBurnRoleGlobally({
             manager: frank.address,
             tokenIdentifier: tx1Outcome.tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -162,7 +160,7 @@ describe("test factory on testnet", function () {
         const tx3 = factory.setBurnRoleGlobally({
             manager: frank.address,
             tokenIdentifier: tx1Outcome.tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx3OnNetwork = await processTransaction(frank, tx3, "tx3");
@@ -184,12 +182,10 @@ describe("test factory on testnet", function () {
             canFreeze: true,
             canWipe: true,
             canPause: true,
-            canMint: true,
-            canBurn: true,
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -204,7 +200,7 @@ describe("test factory on testnet", function () {
             tokenIdentifier: tx1Outcome.tokenIdentifier,
             addRoleLocalMint: true,
             addRoleLocalBurn: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -218,7 +214,7 @@ describe("test factory on testnet", function () {
             user: grace.address,
             tokenIdentifier: tokenIdentifier,
             supplyToMint: 200,
-            transactionNonce: grace.account.nonce
+            transactionNonce: grace.account.nonce,
         });
 
         const tx3OnNetwork = await processTransaction(grace, tx3, "tx3");
@@ -231,7 +227,7 @@ describe("test factory on testnet", function () {
             user: grace.address,
             tokenIdentifier: tokenIdentifier,
             supplyToBurn: 50,
-            transactionNonce: grace.account.nonce
+            transactionNonce: grace.account.nonce,
         });
 
         const tx4OnNetwork = await processTransaction(grace, tx4, "tx4");
@@ -253,12 +249,10 @@ describe("test factory on testnet", function () {
             canFreeze: true,
             canWipe: true,
             canPause: true,
-            canMint: true,
-            canBurn: true,
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -270,7 +264,7 @@ describe("test factory on testnet", function () {
         const tx2 = factory.pause({
             manager: frank.address,
             tokenIdentifier: tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -280,7 +274,7 @@ describe("test factory on testnet", function () {
         const tx3 = factory.unpause({
             manager: frank.address,
             tokenIdentifier: tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx3OnNetwork = await processTransaction(frank, tx3, "tx3");
@@ -292,7 +286,7 @@ describe("test factory on testnet", function () {
             sender: frank.account.address,
             receiver: grace.account.address,
             chainID: network.ChainID,
-            nonce: frank.account.nonce
+            nonce: frank.account.nonce,
         });
 
         const _tx4OnNetwork = await processTransaction(frank, tx4, "tx4");
@@ -312,12 +306,10 @@ describe("test factory on testnet", function () {
             canFreeze: true,
             canWipe: true,
             canPause: true,
-            canMint: true,
-            canBurn: true,
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -331,7 +323,7 @@ describe("test factory on testnet", function () {
             sender: frank.account.address,
             receiver: grace.account.address,
             chainID: network.ChainID,
-            nonce: frank.account.nonce
+            nonce: frank.account.nonce,
         });
 
         const _tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -341,7 +333,7 @@ describe("test factory on testnet", function () {
             manager: frank.address,
             user: grace.address,
             tokenIdentifier: tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx3OnNetwork = await processTransaction(frank, tx3, "tx3");
@@ -356,7 +348,7 @@ describe("test factory on testnet", function () {
             manager: frank.address,
             user: grace.address,
             tokenIdentifier: tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx4OnNetwork = await processTransaction(frank, tx4, "tx4");
@@ -381,12 +373,10 @@ describe("test factory on testnet", function () {
             canFreeze: true,
             canWipe: true,
             canPause: true,
-            canMint: true,
-            canBurn: true,
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -400,7 +390,7 @@ describe("test factory on testnet", function () {
             sender: frank.account.address,
             receiver: grace.account.address,
             chainID: network.ChainID,
-            nonce: frank.account.nonce
+            nonce: frank.account.nonce,
         });
 
         const _tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -410,7 +400,7 @@ describe("test factory on testnet", function () {
             manager: frank.address,
             user: grace.address,
             tokenIdentifier: tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx3OnNetwork = await processTransaction(frank, tx3, "tx3");
@@ -425,7 +415,7 @@ describe("test factory on testnet", function () {
             manager: frank.address,
             user: grace.address,
             tokenIdentifier: tokenIdentifier,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx4OnNetwork = await processTransaction(frank, tx4, "tx4");
@@ -453,7 +443,7 @@ describe("test factory on testnet", function () {
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -471,7 +461,7 @@ describe("test factory on testnet", function () {
             addRoleNFTUpdateAttributes: true,
             addRoleNFTAddURI: true,
             addRoleESDTTransferRole: false,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -491,7 +481,7 @@ describe("test factory on testnet", function () {
                 hash: "abba",
                 attributes: Buffer.from("test"),
                 uris: ["a", "b"],
-                transactionNonce: grace.account.nonce
+                transactionNonce: grace.account.nonce,
             });
 
             const txCreateOnNetwork = await processTransaction(grace, txCreate, "txCreate");
@@ -536,7 +526,7 @@ describe("test factory on testnet", function () {
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -553,7 +543,7 @@ describe("test factory on testnet", function () {
             addRoleNFTBurn: false,
             addRoleNFTAddQuantity: true,
             addRoleESDTTransferRole: false,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -572,7 +562,7 @@ describe("test factory on testnet", function () {
                 hash: "abba",
                 attributes: Buffer.from("test"),
                 uris: ["a", "b"],
-                transactionNonce: grace.account.nonce
+                transactionNonce: grace.account.nonce,
             });
 
             const txCreateOnNetwork = await processTransaction(grace, txCreate, "txCreate");
@@ -588,7 +578,7 @@ describe("test factory on testnet", function () {
                 tokenIdentifier: txCreateOutcome.tokenIdentifier,
                 tokenNonce: txCreateOutcome.nonce,
                 quantityToAdd: "3",
-                transactionNonce: grace.account.nonce
+                transactionNonce: grace.account.nonce,
             });
 
             const txAddQuantityOnNetwork = await processTransaction(grace, txAddQuantity, "txAddQuantity");
@@ -604,7 +594,7 @@ describe("test factory on testnet", function () {
                 tokenIdentifier: txCreateOutcome.tokenIdentifier,
                 tokenNonce: txCreateOutcome.nonce,
                 quantityToBurn: "2",
-                transactionNonce: grace.account.nonce
+                transactionNonce: grace.account.nonce,
             });
 
             const txBurnQuantityOnNetwork = await processTransaction(grace, txBurnQuantity, "txBurnQuantity");
@@ -634,7 +624,7 @@ describe("test factory on testnet", function () {
             canChangeOwner: true,
             canUpgrade: true,
             canAddSpecialRoles: true,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx1OnNetwork = await processTransaction(frank, tx1, "tx1");
@@ -651,7 +641,7 @@ describe("test factory on testnet", function () {
             addRoleNFTBurn: false,
             addRoleNFTAddQuantity: true,
             addRoleESDTTransferRole: false,
-            transactionNonce: frank.account.nonce
+            transactionNonce: frank.account.nonce,
         });
 
         const tx2OnNetwork = await processTransaction(frank, tx2, "tx2");
@@ -670,7 +660,7 @@ describe("test factory on testnet", function () {
                 hash: "abba",
                 attributes: Buffer.from("test"),
                 uris: ["a", "b"],
-                transactionNonce: grace.account.nonce
+                transactionNonce: grace.account.nonce,
             });
 
             const txOnNetwork = await processTransaction(grace, tx, "tx");
@@ -682,7 +672,11 @@ describe("test factory on testnet", function () {
         }
     });
 
-    async function processTransaction(wallet: TestWallet, transaction: Transaction, tag: string): Promise<ITransactionOnNetwork> {
+    async function processTransaction(
+        wallet: TestWallet,
+        transaction: Transaction,
+        tag: string
+    ): Promise<ITransactionOnNetwork> {
         wallet.account.incrementNonce();
         await wallet.signer.sign(transaction);
         await provider.sendTransaction(transaction);

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -48,16 +48,6 @@ interface IIssueFungibleArgs extends IBaseArgs {
     canChangeOwner: boolean;
     canUpgrade: boolean;
     canAddSpecialRoles: boolean;
-
-    /**
-     * @deprecated (not used anymore)
-     */
-    canMint?: boolean;
-
-    /**
-     * @deprecated (not used anymore)
-     */
-    canBurn?: boolean;
 }
 
 interface IIssueSemiFungibleArgs extends IBaseArgs {
@@ -73,8 +63,7 @@ interface IIssueSemiFungibleArgs extends IBaseArgs {
     canAddSpecialRoles: boolean;
 }
 
-interface IIssueNonFungibleArgs extends IIssueSemiFungibleArgs {
-}
+interface IIssueNonFungibleArgs extends IIssueSemiFungibleArgs {}
 
 interface IRegisterMetaESDT extends IIssueSemiFungibleArgs {
     numDecimals: number;
@@ -156,14 +145,14 @@ interface ILocalMintArgs extends IBaseArgs {
     manager: IAddress;
     user: IAddress;
     tokenIdentifier: string;
-    supplyToMint: BigNumber.Value
+    supplyToMint: BigNumber.Value;
 }
 
 interface ILocalBurnArgs extends IBaseArgs {
     manager: IAddress;
     user: IAddress;
     tokenIdentifier: string;
-    supplyToBurn: BigNumber.Value
+    supplyToBurn: BigNumber.Value;
 }
 
 interface IUpdateAttributesArgs extends IBaseArgs {
@@ -177,14 +166,14 @@ interface IAddQuantityArgs extends IBaseArgs {
     manager: IAddress;
     tokenIdentifier: string;
     tokenNonce: BigNumber.Value;
-    quantityToAdd: BigNumber.Value
+    quantityToAdd: BigNumber.Value;
 }
 
 interface IBurnQuantityArgs extends IBaseArgs {
     manager: IAddress;
     tokenIdentifier: string;
     tokenNonce: BigNumber.Value;
-    quantityToBurn: BigNumber.Value
+    quantityToBurn: BigNumber.Value;
 }
 
 export class TokenOperationsFactory {
@@ -221,7 +210,7 @@ export class TokenOperationsFactory {
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitIssue,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -258,7 +247,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitIssue,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -286,7 +275,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitIssue,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -315,7 +304,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitIssue,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -327,7 +316,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             utf8ToHex(args.tokenName),
             utf8ToHex(args.tokenTicker),
             utf8ToHex(args.tokenType),
-            bigIntToHex(args.numDecimals)
+            bigIntToHex(args.numDecimals),
         ];
 
         return this.createTransaction({
@@ -338,15 +327,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitIssue,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     setBurnRoleGlobally(args: IToggleBurnRoleGloballyArgs): Transaction {
-        const parts = [
-            "setBurnRoleGlobally",
-            utf8ToHex(args.tokenIdentifier)
-        ];
+        const parts = ["setBurnRoleGlobally", utf8ToHex(args.tokenIdentifier)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -355,15 +341,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitToggleBurnRoleGlobally,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     unsetBurnRoleGlobally(args: IToggleBurnRoleGloballyArgs): Transaction {
-        const parts = [
-            "unsetBurnRoleGlobally",
-            utf8ToHex(args.tokenIdentifier)
-        ];
+        const parts = ["unsetBurnRoleGlobally", utf8ToHex(args.tokenIdentifier)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -372,7 +355,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitToggleBurnRoleGlobally,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -392,7 +375,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitSetSpecialRole,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -414,7 +397,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitSetSpecialRole,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -441,7 +424,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitSetSpecialRole,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -468,15 +451,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitESDTNFTCreate.valueOf() + storageGasLimit.valueOf(),
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     pause(args: IPausingArgs): Transaction {
-        const parts = [
-            "pause",
-            utf8ToHex(args.tokenIdentifier)
-        ];
+        const parts = ["pause", utf8ToHex(args.tokenIdentifier)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -485,15 +465,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitPausing,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     unpause(args: IPausingArgs): Transaction {
-        const parts = [
-            "unPause",
-            utf8ToHex(args.tokenIdentifier)
-        ];
+        const parts = ["unPause", utf8ToHex(args.tokenIdentifier)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -502,16 +479,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitPausing,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     freeze(args: IFreezingArgs): Transaction {
-        const parts = [
-            "freeze",
-            utf8ToHex(args.tokenIdentifier),
-            addressToHex(args.user)
-        ];
+        const parts = ["freeze", utf8ToHex(args.tokenIdentifier), addressToHex(args.user)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -520,16 +493,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitFreezing,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     unfreeze(args: IFreezingArgs): Transaction {
-        const parts = [
-            "unFreeze",
-            utf8ToHex(args.tokenIdentifier),
-            addressToHex(args.user)
-        ];
+        const parts = ["unFreeze", utf8ToHex(args.tokenIdentifier), addressToHex(args.user)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -538,16 +507,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitFreezing,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     wipe(args: IWipingArgs): Transaction {
-        const parts = [
-            "wipe",
-            utf8ToHex(args.tokenIdentifier),
-            addressToHex(args.user)
-        ];
+        const parts = ["wipe", utf8ToHex(args.tokenIdentifier), addressToHex(args.user)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -556,16 +521,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitWiping,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     localMint(args: ILocalMintArgs): Transaction {
-        const parts = [
-            "ESDTLocalMint",
-            utf8ToHex(args.tokenIdentifier),
-            bigIntToHex(args.supplyToMint),
-        ];
+        const parts = ["ESDTLocalMint", utf8ToHex(args.tokenIdentifier), bigIntToHex(args.supplyToMint)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -574,16 +535,12 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitESDTLocalMint,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
     localBurn(args: ILocalBurnArgs): Transaction {
-        const parts = [
-            "ESDTLocalBurn",
-            utf8ToHex(args.tokenIdentifier),
-            bigIntToHex(args.supplyToBurn),
-        ];
+        const parts = ["ESDTLocalBurn", utf8ToHex(args.tokenIdentifier), bigIntToHex(args.supplyToBurn)];
 
         return this.createTransaction({
             sender: args.manager,
@@ -592,7 +549,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitESDTLocalBurn,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -611,7 +568,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitESDTNFTUpdateAttributes,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -620,7 +577,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             "ESDTNFTAddQuantity",
             utf8ToHex(args.tokenIdentifier),
             bigIntToHex(args.tokenNonce),
-            bigIntToHex(args.quantityToAdd)
+            bigIntToHex(args.quantityToAdd),
         ];
 
         return this.createTransaction({
@@ -630,7 +587,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitESDTNFTAddQuantity,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
@@ -639,7 +596,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             "ESDTNFTBurn",
             utf8ToHex(args.tokenIdentifier),
             bigIntToHex(args.tokenNonce),
-            bigIntToHex(args.quantityToBurn)
+            bigIntToHex(args.quantityToBurn),
         ];
 
         return this.createTransaction({
@@ -649,11 +606,20 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             gasPrice: args.gasPrice,
             gasLimitHint: args.gasLimit,
             executionGasLimit: this.config.gasLimitESDTNFTBurn,
-            dataParts: parts
+            dataParts: parts,
         });
     }
 
-    private createTransaction({ sender, receiver, nonce, value, gasPrice, gasLimitHint, executionGasLimit, dataParts }: {
+    private createTransaction({
+        sender,
+        receiver,
+        nonce,
+        value,
+        gasPrice,
+        gasLimitHint,
+        executionGasLimit,
+        dataParts,
+    }: {
         sender: IAddress;
         receiver: IAddress;
         nonce?: INonce;
@@ -678,7 +644,7 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             value: value || 0,
             data: payload,
             version: version,
-            options: options
+            options: options,
         });
     }
 
@@ -688,7 +654,8 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
     }
 
     private computeGasLimit(payload: TransactionPayload, executionGas: IGasLimit): IGasLimit {
-        const dataMovementGas = this.config.minGasLimit.valueOf() + this.config.gasLimitPerByte.valueOf() * payload.length();
+        const dataMovementGas =
+            this.config.minGasLimit.valueOf() + this.config.gasLimitPerByte.valueOf() * payload.length();
         return dataMovementGas + executionGas.valueOf();
     }
 }


### PR DESCRIPTION
The `tokenOperationsFactory` still had `canMint` and `canBurn` that are not needed anymore.
It's more a "fixing change" rather than a breaking change.