### PR TITLE
Fix flags when creating token management transactions

### DIFF
--- a/src/tokenOperations/tokenOperationsFactory.spec.ts
+++ b/src/tokenOperations/tokenOperationsFactory.spec.ts
@@ -39,12 +39,12 @@ describe("test factory", () => {
             canWipe: true,
             canPause: true,
             canChangeOwner: true,
-            canUpgrade: true,
-            canAddSpecialRoles: true,
+            canUpgrade: false,
+            canAddSpecialRoles: false,
             transactionNonce: 42
         });
 
-        assert.equal(transaction.getData().toString(), "issue@4652414e4b@4652414e4b@64@@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565")
+        assert.equal(transaction.getData().toString(), "issue@4652414e4b@4652414e4b@64@@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365")
         assert.equal(transaction.getNonce(), 42);
         assert.equal(transaction.getSender().toString(), frank.address.toString());
         assert.equal(transaction.getReceiver().toString(), "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");
@@ -60,12 +60,12 @@ describe("test factory", () => {
             canPause: true,
             canTransferNFTCreateRole: true,
             canChangeOwner: true,
-            canUpgrade: true,
-            canAddSpecialRoles: true,
+            canUpgrade: false,
+            canAddSpecialRoles: false,
             transactionNonce: 42
         });
 
-        assert.equal(transaction.getData().toString(), "issueSemiFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565")
+        assert.equal(transaction.getData().toString(), "issueSemiFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365")
         assert.equal(transaction.getNonce(), 42);
         assert.equal(transaction.getSender().toString(), frank.address.toString());
         assert.equal(transaction.getReceiver().toString(), "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");
@@ -81,12 +81,12 @@ describe("test factory", () => {
             canPause: true,
             canTransferNFTCreateRole: true,
             canChangeOwner: true,
-            canUpgrade: true,
-            canAddSpecialRoles: true,
+            canUpgrade: false,
+            canAddSpecialRoles: false,
             transactionNonce: 42
         });
 
-        assert.equal(transaction.getData().toString(), "issueNonFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565")
+        assert.equal(transaction.getData().toString(), "issueNonFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365")
         assert.equal(transaction.getNonce(), 42);
         assert.equal(transaction.getSender().toString(), frank.address.toString());
         assert.equal(transaction.getReceiver().toString(), "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");
@@ -103,12 +103,12 @@ describe("test factory", () => {
             canPause: true,
             canTransferNFTCreateRole: true,
             canChangeOwner: true,
-            canUpgrade: true,
-            canAddSpecialRoles: true,
+            canUpgrade: false,
+            canAddSpecialRoles: false,
             transactionNonce: 42
         });
 
-        assert.equal(transaction.getData().toString(), "registerMetaESDT@4652414e4b@4652414e4b@0a@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565")
+        assert.equal(transaction.getData().toString(), "registerMetaESDT@4652414e4b@4652414e4b@0a@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365")
         assert.equal(transaction.getNonce(), 42);
         assert.equal(transaction.getSender().toString(), frank.address.toString());
         assert.equal(transaction.getReceiver().toString(), "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");

--- a/src/tokenOperations/tokenOperationsFactory.ts
+++ b/src/tokenOperations/tokenOperationsFactory.ts
@@ -63,7 +63,7 @@ interface IIssueSemiFungibleArgs extends IBaseArgs {
     canAddSpecialRoles: boolean;
 }
 
-interface IIssueNonFungibleArgs extends IIssueSemiFungibleArgs {}
+interface IIssueNonFungibleArgs extends IIssueSemiFungibleArgs { }
 
 interface IRegisterMetaESDT extends IIssueSemiFungibleArgs {
     numDecimals: number;
@@ -179,10 +179,12 @@ interface IBurnQuantityArgs extends IBaseArgs {
 export class TokenOperationsFactory {
     private readonly config: IConfig;
     private readonly trueAsHex;
+    private readonly falseAsHex;
 
     constructor(config: IConfig) {
         this.config = config;
         this.trueAsHex = utf8ToHex("true");
+        this.falseAsHex = utf8ToHex("false");
     }
 
     issueFungible(args: IIssueFungibleArgs): Transaction {
@@ -194,12 +196,18 @@ export class TokenOperationsFactory {
             utf8ToHex(args.tokenTicker),
             bigIntToHex(args.initialSupply),
             bigIntToHex(args.numDecimals),
-            ...(args.canFreeze ? [utf8ToHex("canFreeze"), this.trueAsHex] : []),
-            ...(args.canWipe ? [utf8ToHex("canWipe"), this.trueAsHex] : []),
-            ...(args.canPause ? [utf8ToHex("canPause"), this.trueAsHex] : []),
-            ...(args.canChangeOwner ? [utf8ToHex("canChangeOwner"), this.trueAsHex] : []),
-            ...(args.canUpgrade ? [utf8ToHex("canUpgrade"), this.trueAsHex] : []),
-            ...(args.canAddSpecialRoles ? [utf8ToHex("canAddSpecialRoles"), this.trueAsHex] : []),
+            utf8ToHex("canFreeze"),
+            args.canFreeze ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canWipe"),
+            args.canWipe ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canPause"),
+            args.canPause ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canChangeOwner"),
+            args.canChangeOwner ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canUpgrade"),
+            args.canUpgrade ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canAddSpecialRoles"),
+            args.canAddSpecialRoles ? this.trueAsHex : this.falseAsHex
         ];
 
         return this.createTransaction({
@@ -230,13 +238,20 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             "issueSemiFungible",
             utf8ToHex(args.tokenName),
             utf8ToHex(args.tokenTicker),
-            ...(args.canFreeze ? [utf8ToHex("canFreeze"), this.trueAsHex] : []),
-            ...(args.canWipe ? [utf8ToHex("canWipe"), this.trueAsHex] : []),
-            ...(args.canPause ? [utf8ToHex("canPause"), this.trueAsHex] : []),
-            ...(args.canTransferNFTCreateRole ? [utf8ToHex("canTransferNFTCreateRole"), this.trueAsHex] : []),
-            ...(args.canChangeOwner ? [utf8ToHex("canChangeOwner"), this.trueAsHex] : []),
-            ...(args.canUpgrade ? [utf8ToHex("canUpgrade"), this.trueAsHex] : []),
-            ...(args.canAddSpecialRoles ? [utf8ToHex("canAddSpecialRoles"), this.trueAsHex] : []),
+            utf8ToHex("canFreeze"),
+            args.canFreeze ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canWipe"),
+            args.canWipe ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canPause"),
+            args.canPause ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canTransferNFTCreateRole"),
+            args.canTransferNFTCreateRole ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canChangeOwner"),
+            args.canChangeOwner ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canUpgrade"),
+            args.canUpgrade ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canAddSpecialRoles"),
+            args.canAddSpecialRoles ? this.trueAsHex : this.falseAsHex
         ];
 
         return this.createTransaction({
@@ -258,13 +273,20 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             "issueNonFungible",
             utf8ToHex(args.tokenName),
             utf8ToHex(args.tokenTicker),
-            ...(args.canFreeze ? [utf8ToHex("canFreeze"), this.trueAsHex] : []),
-            ...(args.canWipe ? [utf8ToHex("canWipe"), this.trueAsHex] : []),
-            ...(args.canPause ? [utf8ToHex("canPause"), this.trueAsHex] : []),
-            ...(args.canTransferNFTCreateRole ? [utf8ToHex("canTransferNFTCreateRole"), this.trueAsHex] : []),
-            ...(args.canChangeOwner ? [utf8ToHex("canChangeOwner"), this.trueAsHex] : []),
-            ...(args.canUpgrade ? [utf8ToHex("canUpgrade"), this.trueAsHex] : []),
-            ...(args.canAddSpecialRoles ? [utf8ToHex("canAddSpecialRoles"), this.trueAsHex] : []),
+            utf8ToHex("canFreeze"),
+            args.canFreeze ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canWipe"),
+            args.canWipe ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canPause"),
+            args.canPause ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canTransferNFTCreateRole"),
+            args.canTransferNFTCreateRole ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canChangeOwner"),
+            args.canChangeOwner ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canUpgrade"),
+            args.canUpgrade ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canAddSpecialRoles"),
+            args.canAddSpecialRoles ? this.trueAsHex : this.falseAsHex
         ];
 
         return this.createTransaction({
@@ -287,13 +309,20 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             utf8ToHex(args.tokenName),
             utf8ToHex(args.tokenTicker),
             bigIntToHex(args.numDecimals),
-            ...(args.canFreeze ? [utf8ToHex("canFreeze"), this.trueAsHex] : []),
-            ...(args.canWipe ? [utf8ToHex("canWipe"), this.trueAsHex] : []),
-            ...(args.canPause ? [utf8ToHex("canPause"), this.trueAsHex] : []),
-            ...(args.canTransferNFTCreateRole ? [utf8ToHex("canTransferNFTCreateRole"), this.trueAsHex] : []),
-            ...(args.canChangeOwner ? [utf8ToHex("canChangeOwner"), this.trueAsHex] : []),
-            ...(args.canUpgrade ? [utf8ToHex("canUpgrade"), this.trueAsHex] : []),
-            ...(args.canAddSpecialRoles ? [utf8ToHex("canAddSpecialRoles"), this.trueAsHex] : []),
+            utf8ToHex("canFreeze"),
+            args.canFreeze ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canWipe"),
+            args.canWipe ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canPause"),
+            args.canPause ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canTransferNFTCreateRole"),
+            args.canTransferNFTCreateRole ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canChangeOwner"),
+            args.canChangeOwner ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canUpgrade"),
+            args.canUpgrade ? this.trueAsHex : this.falseAsHex,
+            utf8ToHex("canAddSpecialRoles"),
+            args.canAddSpecialRoles ? this.trueAsHex : this.falseAsHex
         ];
 
         return this.createTransaction({


### PR DESCRIPTION
For transactions that issue (register) tokens, all flags are now explicitly provided (whether they are SET or UNSET), in order to overcome issues related to default values (as handled by the Protocol).

A small amount of extra gasLimit is needed (to account for the slightly larger _transaction.data_ field).