### PR TITLE
Remove old wallet package from dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
       },
       "devDependencies": {
         "@multiversx/sdk-network-providers": "2.2.0",
-        "@multiversx/sdk-wallet": "3.0.0",
-        "@multiversx/sdk-wallet-next": "npm:@multiversx/sdk-wallet@4.0.0",
+        "@multiversx/sdk-wallet": "4.2.0",
         "@types/assert": "1.4.6",
         "@types/chai": "4.2.11",
         "@types/mocha": "9.1.0",
@@ -523,29 +522,9 @@
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@multiversx/sdk-wallet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-3.0.0.tgz",
-      "integrity": "sha512-nDVBtva1mpfutXA8TfUnpdeFqhY9O+deNU3U/Z41yPBcju1trHDC9gcKPyQqcQ3qjG/6LwEXmIm7Dc5fIsvVjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@multiversx/sdk-bls-wasm": "0.3.5",
-        "bech32": "1.1.4",
-        "bip39": "3.0.2",
-        "blake2b": "2.1.3",
-        "ed25519-hd-key": "1.1.2",
-        "ed2curve": "0.3.0",
-        "keccak": "3.0.1",
-        "scryptsy": "2.1.0",
-        "tweetnacl": "1.0.3",
-        "uuid": "8.3.2"
-      }
-    },
-    "node_modules/@multiversx/sdk-wallet-next": {
-      "name": "@multiversx/sdk-wallet",
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-4.0.0.tgz",
-      "integrity": "sha512-Fskqg9AGgqSIAgN+Ag9Y/DIoZRr4qgB0baVZ1nlXhgaRuM30v1UeW0TAIhuAbXkkMiTOJyLaCeebUDYy1VJgWA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-4.2.0.tgz",
+      "integrity": "sha512-EjSb9AnqMcpmDjZ7ebkUpOzpTfxj1plTuVXwZ6AaqJsdpxMfrE2izbPy18+bg5xFlr8V27wYZcW8zOhkBR50BA==",
       "dev": true,
       "dependencies": {
         "@multiversx/sdk-bls-wasm": "0.3.5",
@@ -560,20 +539,6 @@
         "scryptsy": "2.1.0",
         "tweetnacl": "1.0.3",
         "uuid": "8.3.2"
-      }
-    },
-    "node_modules/@multiversx/sdk-wallet-next/node_modules/keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@multiversx/sdk-wallet/node_modules/keccak": {
@@ -4852,39 +4817,9 @@
       }
     },
     "@multiversx/sdk-wallet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-3.0.0.tgz",
-      "integrity": "sha512-nDVBtva1mpfutXA8TfUnpdeFqhY9O+deNU3U/Z41yPBcju1trHDC9gcKPyQqcQ3qjG/6LwEXmIm7Dc5fIsvVjg==",
-      "dev": true,
-      "requires": {
-        "@multiversx/sdk-bls-wasm": "0.3.5",
-        "bech32": "1.1.4",
-        "bip39": "3.0.2",
-        "blake2b": "2.1.3",
-        "ed25519-hd-key": "1.1.2",
-        "ed2curve": "0.3.0",
-        "keccak": "3.0.1",
-        "scryptsy": "2.1.0",
-        "tweetnacl": "1.0.3",
-        "uuid": "8.3.2"
-      },
-      "dependencies": {
-        "keccak": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-          "dev": true,
-          "requires": {
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
-      }
-    },
-    "@multiversx/sdk-wallet-next": {
-      "version": "npm:@multiversx/sdk-wallet@4.0.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-4.0.0.tgz",
-      "integrity": "sha512-Fskqg9AGgqSIAgN+Ag9Y/DIoZRr4qgB0baVZ1nlXhgaRuM30v1UeW0TAIhuAbXkkMiTOJyLaCeebUDYy1VJgWA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-wallet/-/sdk-wallet-4.2.0.tgz",
+      "integrity": "sha512-EjSb9AnqMcpmDjZ7ebkUpOzpTfxj1plTuVXwZ6AaqJsdpxMfrE2izbPy18+bg5xFlr8V27wYZcW8zOhkBR50BA==",
       "dev": true,
       "requires": {
         "@multiversx/sdk-bls-wasm": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   },
   "devDependencies": {
     "@multiversx/sdk-network-providers": "2.2.0",
-    "@multiversx/sdk-wallet": "3.0.0",
-    "@multiversx/sdk-wallet-next": "npm:@multiversx/sdk-wallet@4.0.0",
+    "@multiversx/sdk-wallet": "4.2.0",
     "@types/assert": "1.4.6",
     "@types/chai": "4.2.11",
     "@types/mocha": "9.1.0",

--- a/src/relayedTransactionV1Builder.spec.ts
+++ b/src/relayedTransactionV1Builder.spec.ts
@@ -61,7 +61,7 @@ describe("test relayed v1 transaction builder", function () {
             data: new TransactionPayload("getContractConfig"),
         });
 
-        await bob.signer.sign(innerTx);
+        innerTx.applySignature(await bob.signer.sign(innerTx.serializeForSigning()));
 
         const builder = new RelayedTransactionV1Builder();
         const relayedTxV1 = builder
@@ -71,7 +71,7 @@ describe("test relayed v1 transaction builder", function () {
             .setRelayerAddress(alice.address)
             .build();
 
-        await alice.signer.sign(relayedTxV1);
+        relayedTxV1.applySignature(await alice.signer.sign(relayedTxV1.serializeForSigning()));
 
         assert.equal(relayedTxV1.getNonce().valueOf(), 2627);
         assert.equal(relayedTxV1.getData().toString(), "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414141415141414141414141414141414141414141414141414141414141432f2f383d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225a3256305132397564484a68593352446232356d6157633d222c227369676e6174757265223a2239682b6e6742584f5536776674315464437368534d4b3454446a5a32794f74686336564c576e3478724d5a706248427738677a6c6659596d362b766b505258303764634a562b4745635462616a7049692b5a5a5942773d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a317d");
@@ -97,7 +97,7 @@ describe("test relayed v1 transaction builder", function () {
             chainID: networkConfig.ChainID
         });
 
-        await carol.signer.sign(innerTx);
+        innerTx.applySignature(await carol.signer.sign(innerTx.serializeForSigning()));
 
         const builder = new RelayedTransactionV1Builder();
         const relayedTxV1 = builder
@@ -107,7 +107,7 @@ describe("test relayed v1 transaction builder", function () {
             .setRelayerAddress(frank.address)
             .build();
 
-        await frank.signer.sign(relayedTxV1);
+        relayedTxV1.applySignature(await frank.signer.sign(relayedTxV1.serializeForSigning()));
 
         assert.equal(relayedTxV1.getNonce().valueOf(), 715);
         assert.equal(relayedTxV1.getData().toString(), "relayedTx@7b226e6f6e6365223a3230382c2273656e646572223a227371455656633553486b6c45344a717864556e59573068397a536249533141586f3534786f32634969626f3d222c227265636569766572223a2241546c484c76396f686e63616d433877673970645168386b77704742356a6949496f3349484b594e6165453d222c2276616c7565223a313030303030303030303030303030303030302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a22744d616d736b6f315a574b526663594e4b5673793463797879643335764b754844576a3548706172344167734c2b4a4e585642545a574c754467384867514254476d724a6b49443133637050614c55322f38626644513d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a312c22736e64557365724e616d65223a22593246796232773d222c22726376557365724e616d65223a22595778705932553d227d");
@@ -134,7 +134,7 @@ describe("test relayed v1 transaction builder", function () {
             options: TransactionOptions.withOptions({ guarded: true })
         });
 
-        await bob.signer.sign(innerTx);
+        innerTx.applySignature(await bob.signer.sign(innerTx.serializeForSigning()));
         innerTx.applyGuardianSignature(new Signature("c72e08622c86d9b6889fb9f33eed75c6a04a940daa012825464c6ccaad71640cfcf5c4d38b36fb0575345bbec90daeb2db7a423bfb5253cef0ddc5c87d1b5f04"));
 
         const builder = new RelayedTransactionV1Builder();
@@ -145,7 +145,7 @@ describe("test relayed v1 transaction builder", function () {
             .setRelayerAddress(alice.address)
             .build();
 
-        await alice.signer.sign(relayedTxV1);
+        relayedTxV1.applySignature(await alice.signer.sign(relayedTxV1.serializeForSigning()));
 
         assert.equal(relayedTxV1.getNonce().valueOf(), 2627);
         assert.equal(relayedTxV1.getData().toString(), "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414146414b565841323879704877692f79693741364c64504b704f68464d386958513d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225a3256305132397564484a68593352446232356d6157633d222c227369676e6174757265223a224b4b78324f33383655725135416b4f465258307578327933446a384853334b373038487174344668377161557669424550716c45614e746e6158706a6f2f333651476d4a456934784435457a6c6f4f677a634d4442773d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a322c226f7074696f6e73223a322c22677561726469616e223a22486f714c61306e655733766843716f56696c70715372744c5673774939535337586d7a563868477450684d3d222c22677561726469616e5369676e6174757265223a227879344959697947326261496e376e7a507531317871424b6c4132714153676c526b7873797131785a417a3839635454697a6237425855305737374a44613679323370434f2f745355383777336358496652746642413d3d227d");
@@ -172,7 +172,7 @@ describe("test relayed v1 transaction builder", function () {
             options: TransactionOptions.withOptions({ guarded: true })
         });
 
-        await bob.signer.sign(innerTx);
+        innerTx.applySignature(await bob.signer.sign(innerTx.serializeForSigning()));
         innerTx.applyGuardianSignature(new Signature("b12d08732c86d9b6889fb9f33eed65c6a04a960daa012825464c6ccaad71640cfcf5c4d38b36fb0575345bbec90daeb2db7a423bfb5253cef0ddc5c87d1b5f04"));
 
         const builder = new RelayedTransactionV1Builder();
@@ -186,7 +186,7 @@ describe("test relayed v1 transaction builder", function () {
             .setRelayedTransactionGuardian(frank.address)
             .build();
 
-        await alice.signer.sign(relayedTxV1);
+        relayedTxV1.applySignature(await alice.signer.sign(relayedTxV1.serializeForSigning()));
         relayedTxV1.applyGuardianSignature(new Signature("d32c08722c86d9b6889fb9f33eed65c6a04a970daa012825464c6ccaad71640cfcf5c4d38b36fb0575345bbec90daeb2db7a423bfb5253cef0ddc5c87d1b5f04"));
 
         assert.equal(relayedTxV1.getNonce().valueOf(), 2627);

--- a/src/relayedTransactionV2Builder.spec.ts
+++ b/src/relayedTransactionV2Builder.spec.ts
@@ -69,7 +69,7 @@ describe("test relayed v2 transaction builder", function () {
             data: new TransactionPayload("getContractConfig"),
         });
 
-        await bob.signer.sign(innerTx);
+        innerTx.applySignature(await bob.signer.sign(innerTx.serializeForSigning()));
 
         const builder = new RelayedTransactionV2Builder();
         const relayedTxV2 = builder
@@ -81,7 +81,7 @@ describe("test relayed v2 transaction builder", function () {
             .build();
 
         relayedTxV2.setSender(alice.address);
-        await alice.signer.sign(relayedTxV2);
+        relayedTxV2.applySignature(await alice.signer.sign(relayedTxV2.serializeForSigning()));
 
         assert.equal(relayedTxV2.getNonce().valueOf(), 37);
         assert.equal(

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -184,7 +184,7 @@ describe("test smart contract interactor", function () {
         // Execute, do not wait for execution
         let transaction = interaction.withSender(alice.address).withNonce(0).buildTransaction();
         transaction.setSender(alice.address);
-        await alice.signer.sign(transaction);
+        transaction.applySignature(await alice.signer.sign(transaction.serializeForSigning()));
         await provider.sendTransaction(transaction);
         assert.equal(transaction.getNonce().valueOf(), 0);
         assert.equal(transaction.getData().toString(), "getUltimateAnswer");
@@ -195,7 +195,7 @@ describe("test smart contract interactor", function () {
 
         transaction = interaction.withNonce(1).buildTransaction();
         transaction.setSender(alice.address);
-        await alice.signer.sign(transaction);
+        transaction.applySignature(await alice.signer.sign(transaction.serializeForSigning()));
         await provider.sendTransaction(transaction);
         assert.equal(transaction.getNonce().valueOf(), 1);
         assert.equal(
@@ -206,7 +206,7 @@ describe("test smart contract interactor", function () {
         // Execute, and wait for execution
         transaction = interaction.withNonce(2).buildTransaction();
         transaction.setSender(alice.address);
-        await alice.signer.sign(transaction);
+        transaction.applySignature(await alice.signer.sign(transaction.serializeForSigning()));
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@2bs");
         let { bundle } = await controller.execute(interaction, transaction);
 
@@ -238,7 +238,7 @@ describe("test smart contract interactor", function () {
         assert.deepEqual(counterValue!.valueOf(), new BigNumber(7));
 
         let incrementTransaction = incrementInteraction.withSender(alice.address).withNonce(14).buildTransaction();
-        await alice.signer.sign(incrementTransaction);
+        incrementTransaction.applySignature(await alice.signer.sign(incrementTransaction.serializeForSigning()));
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@08");
         let { bundle: { firstValue: valueAfterIncrement } } = await controller.execute(incrementInteraction, incrementTransaction);
         assert.deepEqual(valueAfterIncrement!.valueOf(), new BigNumber(8));
@@ -246,16 +246,16 @@ describe("test smart contract interactor", function () {
         // Decrement three times (simulate three parallel broadcasts). Wait for execution of the latter (third transaction). Return fake "5".
         // Decrement #1
         let decrementTransaction = decrementInteraction.withSender(alice.address).withNonce(15).buildTransaction();
-        await alice.signer.sign(decrementTransaction);
+        decrementTransaction.applySignature(await alice.signer.sign(decrementTransaction.serializeForSigning()));
         await provider.sendTransaction(decrementTransaction);
         // Decrement #2
         decrementTransaction = decrementInteraction.withNonce(16).buildTransaction();
-        await alice.signer.sign(decrementTransaction);
+        decrementTransaction.applySignature(await alice.signer.sign(decrementTransaction.serializeForSigning()));
         await provider.sendTransaction(decrementTransaction);
         // Decrement #3
 
         decrementTransaction = decrementInteraction.withNonce(17).buildTransaction();
-        await alice.signer.sign(decrementTransaction);
+        decrementTransaction.applySignature(await alice.signer.sign(decrementTransaction.serializeForSigning()));
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@05");
         let { bundle: { firstValue: valueAfterDecrement } } = await controller.execute(decrementInteraction, decrementTransaction);
         assert.deepEqual(valueAfterDecrement!.valueOf(), new BigNumber(5));
@@ -295,7 +295,7 @@ describe("test smart contract interactor", function () {
 
         // start()
         let startTransaction = startInteraction.withSender(alice.address).withNonce(14).buildTransaction();
-        await alice.signer.sign(startTransaction);
+        startTransaction.applySignature(await alice.signer.sign(startTransaction.serializeForSigning()));
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b");
         let { bundle: { returnCode: startReturnCode, values: startReturnValues } } = await controller.execute(startInteraction, startTransaction);
 
@@ -305,7 +305,7 @@ describe("test smart contract interactor", function () {
 
         // status() (this is a view function, but for the sake of the test, we'll execute it)
         let statusTransaction = statusInteraction.withSender(alice.address).withNonce(15).buildTransaction();
-        await alice.signer.sign(statusTransaction);
+        statusTransaction.applySignature(await alice.signer.sign(statusTransaction.serializeForSigning()));
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@01");
         let { bundle: { returnCode: statusReturnCode, values: statusReturnValues, firstValue: statusFirstValue } } = await controller.execute(statusInteraction, statusTransaction);
 
@@ -316,7 +316,7 @@ describe("test smart contract interactor", function () {
 
         // lotteryInfo() (this is a view function, but for the sake of the test, we'll execute it)
         let getLotteryInfoTransaction = getLotteryInfoInteraction.withSender(alice.address).withNonce(15).buildTransaction();
-        await alice.signer.sign(getLotteryInfoTransaction);
+        getLotteryInfoTransaction.applySignature(await alice.signer.sign(getLotteryInfoTransaction.serializeForSigning()));
         provider.mockGetTransactionWithAnyHashAsNotarizedWithOneResult("@6f6b@0000000b6c75636b792d746f6b656e000000010100000000000000005fc2b9dbffffffff00000001640000000a140ec80fa7ee88000000");
         let { bundle: { returnCode: infoReturnCode, values: infoReturnValues, firstValue: infoFirstValue } } = await controller.execute(getLotteryInfoInteraction, getLotteryInfoTransaction);
 

--- a/src/smartcontracts/smartContract.local.net.spec.ts
+++ b/src/smartcontracts/smartContract.local.net.spec.ts
@@ -54,7 +54,7 @@ describe("test on local testnet", function () {
             caller: alice.address
         });
         transactionIncrement.setNonce(alice.account.nonce);
-        await alice.signer.sign(transactionIncrement);
+        transactionIncrement.applySignature(await alice.signer.sign(transactionIncrement.serializeForSigning()));
 
         alice.account.incrementNonce();
 
@@ -78,8 +78,8 @@ describe("test on local testnet", function () {
         simulateOne.setNonce(alice.account.nonce);
         simulateTwo.setNonce(alice.account.nonce);
 
-        await alice.signer.sign(simulateOne);
-        await alice.signer.sign(simulateTwo);
+        simulateOne.applySignature(await alice.signer.sign(simulateOne.serializeForSigning()));
+        simulateTwo.applySignature(await alice.signer.sign(simulateTwo.serializeForSigning()));
 
         // Broadcast & execute
         await provider.sendTransaction(transactionDeploy);
@@ -129,7 +129,7 @@ describe("test on local testnet", function () {
             caller: alice.address
         });
         transactionIncrementFirst.setNonce(alice.account.nonce);
-        await alice.signer.sign(transactionIncrementFirst);
+        transactionIncrementFirst.applySignature(await alice.signer.sign(transactionIncrementFirst.serializeForSigning()));
 
         alice.account.incrementNonce();
 
@@ -141,7 +141,7 @@ describe("test on local testnet", function () {
             caller: alice.address
         });
         transactionIncrementSecond.setNonce(alice.account.nonce);
-        await alice.signer.sign(transactionIncrementSecond);
+        transactionIncrementSecond.applySignature(await alice.signer.sign(transactionIncrementSecond.serializeForSigning()));
 
         alice.account.incrementNonce();
 
@@ -204,8 +204,8 @@ describe("test on local testnet", function () {
         transactionMintCarol.setNonce(alice.account.nonce);
         alice.account.incrementNonce();
 
-        await alice.signer.sign(transactionMintBob);
-        await alice.signer.sign(transactionMintCarol);
+        transactionMintBob.applySignature(await alice.signer.sign(transactionMintBob.serializeForSigning()));
+        transactionMintCarol.applySignature(await alice.signer.sign(transactionMintCarol.serializeForSigning()));
 
         // Broadcast & execute
         await provider.sendTransaction(transactionDeploy);
@@ -288,7 +288,7 @@ describe("test on local testnet", function () {
         // Apply nonces and sign the remaining transactions
         transactionStart.setNonce(alice.account.nonce);
 
-        await alice.signer.sign(transactionStart);
+        transactionStart.applySignature(await alice.signer.sign(transactionStart.serializeForSigning()));
 
         // Broadcast & execute
         await provider.sendTransaction(transactionDeploy);

--- a/src/smartcontracts/smartContract.spec.ts
+++ b/src/smartcontracts/smartContract.spec.ts
@@ -57,7 +57,7 @@ describe("test contract", () => {
         assert.equal(contract.getAddress().bech32(), "erd1qqqqqqqqqqqqqpgq3ytm9m8dpeud35v3us20vsafp77smqghd8ss4jtm0q");
 
         // Sign the transaction
-        alice.signer.sign(deployTransaction);
+        deployTransaction.applySignature(await alice.signer.sign(deployTransaction.serializeForSigning()));
 
         // Now let's broadcast the deploy transaction, and wait for its execution.
         let hash = await provider.sendTransaction(deployTransaction);
@@ -109,8 +109,8 @@ describe("test contract", () => {
         assert.equal(callTransactionTwo.getGasLimit().valueOf(), 1500000);
 
         // Sign transactions, broadcast them
-        alice.signer.sign(callTransactionOne);
-        alice.signer.sign(callTransactionTwo);
+        callTransactionOne.applySignature(await alice.signer.sign(callTransactionOne.serializeForSigning()));
+        callTransactionTwo.applySignature(await alice.signer.sign(callTransactionTwo.serializeForSigning()));
 
         let hashOne = await provider.sendTransaction(callTransactionOne);
         let hashTwo = await provider.sendTransaction(callTransactionTwo);
@@ -152,7 +152,7 @@ describe("test contract", () => {
         assert.equal(deployTransaction.getNonce().valueOf(), 42);
 
         // Sign the transaction
-        alice.signer.sign(deployTransaction);
+        deployTransaction.applySignature(await alice.signer.sign(deployTransaction.serializeForSigning()));
 
         // Now let's broadcast the deploy transaction, and wait for its execution.
         let hash = await provider.sendTransaction(deployTransaction);

--- a/src/smartcontracts/smartContractResults.local.net.spec.ts
+++ b/src/smartcontracts/smartContractResults.local.net.spec.ts
@@ -50,7 +50,7 @@ describe("fetch transactions from local testnet", function () {
         });
 
         transactionIncrement.setNonce(alice.account.nonce);
-        await alice.signer.sign(transactionIncrement);
+        transactionIncrement.applySignature(await alice.signer.sign(transactionIncrement.serializeForSigning()));
 
         alice.account.incrementNonce();
 

--- a/src/testutils/utils.ts
+++ b/src/testutils/utils.ts
@@ -34,7 +34,7 @@ export async function prepareDeployment(obj: {
     transaction.setNonce(nonce);
     transaction.setSender(deployer.address)
     contract.setAddress(contractAddress);
-    await deployer.signer.sign(transaction);
+    transaction.applySignature(await deployer.signer.sign(transaction.serializeForSigning()));
 
     return transaction;
 }

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -72,7 +72,6 @@ export class TestWallet {
     readonly secretKeyHex: string;
     readonly secretKey: Buffer;
     readonly signer: UserSigner;
-    readonly signerNext: UserSigner;
     readonly keyFileObject: any;
     readonly pemFileText: any;
     readonly account: Account;
@@ -82,7 +81,6 @@ export class TestWallet {
         this.secretKeyHex = secretKeyHex;
         this.secretKey = Buffer.from(secretKeyHex, "hex");
         this.signer = new UserSigner(UserSecretKey.fromString(secretKeyHex));
-        this.signerNext = new UserSigner(UserSecretKey.fromString(secretKeyHex));
         this.keyFileObject = keyFileObject;
         this.pemFileText = pemFileText;
         this.account = new Account(this.address);

--- a/src/testutils/wallets.ts
+++ b/src/testutils/wallets.ts
@@ -1,5 +1,4 @@
 import { UserSecretKey, UserSigner } from "@multiversx/sdk-wallet";
-import { UserSigner as UserSignerNext } from "@multiversx/sdk-wallet-next";
 import axios from "axios";
 import * as fs from "fs";
 import * as path from "path";
@@ -73,7 +72,7 @@ export class TestWallet {
     readonly secretKeyHex: string;
     readonly secretKey: Buffer;
     readonly signer: UserSigner;
-    readonly signerNext: UserSignerNext;
+    readonly signerNext: UserSigner;
     readonly keyFileObject: any;
     readonly pemFileText: any;
     readonly account: Account;
@@ -83,7 +82,7 @@ export class TestWallet {
         this.secretKeyHex = secretKeyHex;
         this.secretKey = Buffer.from(secretKeyHex, "hex");
         this.signer = new UserSigner(UserSecretKey.fromString(secretKeyHex));
-        this.signerNext = new UserSignerNext(UserSecretKey.fromString(secretKeyHex));
+        this.signerNext = new UserSigner(UserSecretKey.fromString(secretKeyHex));
         this.keyFileObject = keyFileObject;
         this.pemFileText = pemFileText;
         this.account = new Account(this.address);

--- a/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
+++ b/src/tokenOperations/tokenOperationsFactory.test.net.spec.ts
@@ -674,7 +674,7 @@ describe("test factory on testnet", function () {
 
     async function processTransaction(wallet: TestWallet, transaction: Transaction, tag: string): Promise<ITransactionOnNetwork> {
         wallet.account.incrementNonce();
-        await wallet.signer.sign(transaction);
+        transaction.applySignature(await wallet.signer.sign(transaction.serializeForSigning()));
         await provider.sendTransaction(transaction);
         console.log(`Sent transaction [${tag}]: ${transaction.getHash().hex()}`);
 

--- a/src/transaction.spec.ts
+++ b/src/transaction.spec.ts
@@ -51,7 +51,7 @@ describe("test transaction construction", async () => {
             chainID: "local-testnet"
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("b56769014f2bdc5cf9fc4a05356807d71fcf8775c819b0f1b0964625b679c918ffa64862313bfef86f99b38cb84fcdb16fa33ad6eb565276616723405cd8f109", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "eb30c50c8831885ebcfac986d27e949ec02cf25676e22a009b7a486e5431ec2e");
     });
@@ -68,7 +68,7 @@ describe("test transaction construction", async () => {
             chainID: "local-testnet"
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("e47fd437fc17ac9a69f7bf5f85bafa9e7628d851c4f69bd9fedc7e36029708b2e6d168d5cd652ea78beedd06d4440974ca46c403b14071a1a148d4188f6f2c0d", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "95ed9ac933712d7d77721d75eecfc7896873bb0d746417153812132521636872");
     });
@@ -86,7 +86,7 @@ describe("test transaction construction", async () => {
             options: new TransactionOptions(1)
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("c83e69b853a891bf2130c1839362fe2a7a8db327dcc0c9f130497a4f24b0236140b394801bb2e04ce061a6f873cb432bf1bb1e6072e295610904662ac427a30a", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "32fb1681bd532b226b5bdeed61ae62ce9416bf5e92e48caf96253ff72d1670ac");
     });
@@ -103,7 +103,7 @@ describe("test transaction construction", async () => {
             chainID: "local-testnet"
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("9074789e0b4f9b2ac24b1fd351a4dd840afcfeb427b0f93e2a2d429c28c65ee9f4c288ca4dbde79de0e5bcf8c1a5d26e1b1c86203faea923e0edefb0b5099b0c", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "af53e0fc86612d5068862716b5169effdf554951ecc89849b0e836eb0b63fa3e");
     });
@@ -120,7 +120,7 @@ describe("test transaction construction", async () => {
             chainID: "local-testnet"
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("39938d15812708475dfc8125b5d41dbcea0b2e3e7aabbbfceb6ce4f070de3033676a218b73facd88b1432d7d4accab89c6130b3abe5cc7bbbb5146e61d355b03", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "e4a6048d92409cfe50f12e81218cb92f39966c618979a693b8d16320a06061c1");
     });
@@ -138,7 +138,7 @@ describe("test transaction construction", async () => {
             version: new TransactionVersion(1)
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("dfa3e9f2fdec60dcb353bac3b3435b4a2ff251e7e98eaf8620f46c731fc70c8ba5615fd4e208b05e75fe0f7dc44b7a99567e29f94fcd91efac7e67b182cd2a04", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "6ffa1a75f98aaf336bfb87ef13b9b5a477a017158285d34ee2a503668767e69e");
     });
@@ -154,7 +154,7 @@ describe("test transaction construction", async () => {
             chainID: "local-testnet"
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("b56769014f2bdc5cf9fc4a05356807d71fcf8775c819b0f1b0964625b679c918ffa64862313bfef86f99b38cb84fcdb16fa33ad6eb565276616723405cd8f109", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "eb30c50c8831885ebcfac986d27e949ec02cf25676e22a009b7a486e5431ec2e");
 
@@ -173,7 +173,7 @@ describe("test transaction construction", async () => {
             chainID: "local-testnet"
         });
 
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         assert.equal("b56769014f2bdc5cf9fc4a05356807d71fcf8775c819b0f1b0964625b679c918ffa64862313bfef86f99b38cb84fcdb16fa33ad6eb565276616723405cd8f109", transaction.getSignature().toString("hex"));
         assert.equal(transaction.getHash().toString(), "eb30c50c8831885ebcfac986d27e949ec02cf25676e22a009b7a486e5431ec2e");
 
@@ -193,7 +193,7 @@ describe("test transaction construction", async () => {
             chainID: "T"
         });
 
-        await wallets.carol.signer.sign(transaction);
+        transaction.applySignature(await wallets.carol.signer.sign(transaction.serializeForSigning()));
         assert.equal(transaction.getSignature().toString("hex"), "5966dd6b98fc5ecbcd203fa38fac7059ba5c17683099071883b0ad6697386769321d851388a99cb8b81aab625aa2d7e13621432dbd8ab334c5891cd7c7755200");
         assert.equal(transaction.getHash().toString(), "5728fadbc6c1024c4a0d5552eca44e80c182dc9077e58e31d599cf9496c96d1e");
     });
@@ -380,7 +380,7 @@ describe("test transaction construction", async () => {
             version: new TransactionVersion(2),
             options: TransactionOptions.withOptions({ guarded: true })
         });
-        await wallets.alice.signer.sign(transaction);
+        transaction.applySignature(await wallets.alice.signer.sign(transaction.serializeForSigning()));
         transaction.applyGuardianSignature(transaction.getSignature());
         assert.isTrue(transaction.isGuardedTransaction());
     });

--- a/src/transactionsFactories/delegationTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/delegationTransactionsFactory.spec.ts
@@ -3,7 +3,7 @@ import { Address } from "../address";
 import { DelegationTransactionsFactory } from "./delegationTransactionsFactory";
 import { assert } from "chai";
 import { DELEGATION_MANAGER_SC_ADDRESS } from "../constants";
-import { ValidatorPublicKey } from "@multiversx/sdk-wallet-next";
+import { ValidatorPublicKey } from "@multiversx/sdk-wallet";
 import { TransactionsFactoryConfig } from "./transactionsFactoryConfig";
 
 describe("test delegation transactions factory", function () {


### PR DESCRIPTION
Removed old wallet package (v3.0.0) and replaced `sdk-wallet-next(v4.0.0)` to `sdk-wallet(v4.2.0)`.