### PR TITLE
Add address validator static method without throwing errors

### DIFF
--- a/src/address.spec.ts
+++ b/src/address.spec.ts
@@ -44,4 +44,10 @@ describe("test address", () => {
         assert.throw(() => new Address("erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2"), errors.ErrAddressCannotCreate);
         assert.throw(() => new Address("xerd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz"), errors.ErrAddressCannotCreate);
     });
+
+    it("should validate the address without throwing the error", () => {
+        assert.isTrue(Address.isValid(aliceBech32));
+        assert.isFalse(Address.isValid('xerd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz'));
+        assert.isFalse(Address.isValid('erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2'))
+    })
 });

--- a/src/address.ts
+++ b/src/address.ts
@@ -123,6 +123,23 @@ export class Address {
     }
 
     /**
+     * Performs address validation without throwing errors
+     */
+    static isValid(value: string): boolean {
+        const decoded = bech32.decodeUnsafe(value);
+        const prefix = decoded?.prefix;
+        const pubkey = decoded
+            ? Buffer.from(bech32.fromWords(decoded.words))
+            : undefined;
+
+        if (prefix !== HRP || pubkey?.length !== PUBKEY_LENGTH) {
+            return false;
+        }
+        
+        return true;
+    }
+
+    /**
      * Returns the hex representation of the address (pubkey)
      */
     hex(): string {


### PR DESCRIPTION
Having it as a static method on Address would be super helpful. In many cases, it is good to have a validation without the need to try-catch; at least, I found it helpful. But please remove it if it isn't suitable here or if it should be coded differently. The main goal is to have validation for the address (string) without the need for try-catch. 

