### PR TITLE
[FIX] Issue - 379 - unable to send NFT to any destination address

### DIFF
--- a/src/transferTransactionsFactory.ts
+++ b/src/transferTransactionsFactory.ts
@@ -102,7 +102,7 @@ export class TransferTransactionsFactory {
 
         return new Transaction({
             nonce: args.nonce,
-            receiver: args.sender,
+            receiver: args.destination,
             sender: args.sender,
             gasPrice: args.gasPrice,
             gasLimit: args.gasLimit || estimatedGasLimit,


### PR DESCRIPTION
#379 

Changes:
1. Replaced sender address with destination address prop.