### PR TITLE
Commute to ES2020. Partially replace "BigNumber.Value" with "bigint"

### DIFF
--- a/src/tokens.spec.ts
+++ b/src/tokens.spec.ts
@@ -1,12 +1,12 @@
-import { Token, TokenComputer } from "./tokens";
 import { assert } from "chai";
+import { Token, TokenComputer } from "./tokens";
 
 describe("test token computer", async () => {
     const tokenComputer = new TokenComputer();
 
     it("should test if token is fungible", async () => {
-        const fungibleToken = new Token("TEST-123456", 0);
-        const nonFungibleToken = new Token("NFT-987654", 7);
+        const fungibleToken = new Token("TEST-123456", 0n);
+        const nonFungibleToken = new Token("NFT-987654", 7n);
 
         assert.equal(tokenComputer.isFungible(fungibleToken), true);
         assert.equal(tokenComputer.isFungible(nonFungibleToken), false);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,11 +1,10 @@
-import BigNumber from "bignumber.js";
 import { ErrInvalidTokenIdentifier } from "./errors";
 
 export class Token {
     identifier: string;
-    nonce: BigNumber.Value;
+    nonce: bigint;
 
-    constructor(identifier: string, nonce: BigNumber.Value) {
+    constructor(identifier: string, nonce: bigint) {
         this.identifier = identifier;
         this.nonce = nonce;
     }
@@ -13,9 +12,9 @@ export class Token {
 
 export class NextTokenTransfer {
     token: Token;
-    amount: BigNumber.Value;
+    amount: bigint;
 
-    constructor(token: Token, amount: BigNumber.Value) {
+    constructor(token: Token, amount: bigint) {
         this.token = token;
         this.amount = amount;
     }
@@ -25,7 +24,7 @@ export class TokenComputer {
     constructor() {}
 
     isFungible(token: Token): boolean {
-        return token.nonce === 0;
+        return token.nonce == 0n;
     }
 
     extractNonceFromExtendedIdentifier(identifier: string): number {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -24,7 +24,7 @@ export class TokenComputer {
     constructor() {}
 
     isFungible(token: Token): boolean {
-        return token.nonce == 0n;
+        return token.nonce === 0n;
     }
 
     extractNonceFromExtendedIdentifier(identifier: string): number {

--- a/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
@@ -1,15 +1,15 @@
+import BigNumber from "bignumber.js";
 import { assert, expect } from "chai";
-import { SmartContractTransactionsFactory } from "./smartContractTransactionsFactory";
 import { Address } from "../address";
+import { CONTRACT_DEPLOY_ADDRESS } from "../constants";
+import { Err } from "../errors";
+import { U32Value } from "../smartcontracts";
 import { Code } from "../smartcontracts/code";
 import { AbiRegistry } from "../smartcontracts/typesystem/abiRegistry";
-import { U32Value } from "../smartcontracts";
-import { CONTRACT_DEPLOY_ADDRESS } from "../constants";
-import { loadContractCode, loadAbiRegistry } from "../testutils/utils";
-import { Err } from "../errors";
+import { loadAbiRegistry, loadContractCode } from "../testutils/utils";
+import { NextTokenTransfer, Token, TokenComputer } from "../tokens";
+import { SmartContractTransactionsFactory } from "./smartContractTransactionsFactory";
 import { TransactionsFactoryConfig } from "./transactionsFactoryConfig";
-import BigNumber from "bignumber.js";
-import { Token, NextTokenTransfer, TokenComputer } from "../tokens";
 
 describe("test smart contract transactions factory", function () {
     const config = new TransactionsFactoryConfig("D");
@@ -149,8 +149,8 @@ describe("test smart contract transactions factory", function () {
         const func = "add";
         const gasLimit = 6000000;
         const args = [new U32Value(7)];
-        const token = new Token("FOO-6ce17b", 0);
-        const transfer = new NextTokenTransfer(token, 10);
+        const token = new Token("FOO-6ce17b", 0n);
+        const transfer = new NextTokenTransfer(token, 10n);
 
         const transaction = smartContractFactory.createTransactionForExecute({
             sender: sender,
@@ -185,10 +185,10 @@ describe("test smart contract transactions factory", function () {
         const gasLimit = 6000000;
         const args = [new U32Value(7)];
 
-        const fooToken = new Token("FOO-6ce17b", 0);
-        const fooTransfer = new NextTokenTransfer(fooToken, 10);
-        const barToken = new Token("BAR-5bc08f", 0);
-        const barTransfer = new NextTokenTransfer(barToken, 3140);
+        const fooToken = new Token("FOO-6ce17b", 0n);
+        const fooTransfer = new NextTokenTransfer(fooToken, 10n);
+        const barToken = new Token("BAR-5bc08f", 0n);
+        const barTransfer = new NextTokenTransfer(barToken, 3140n);
 
         const transaction = smartContractFactory.createTransactionForExecute({
             sender: sender,
@@ -230,8 +230,8 @@ describe("test smart contract transactions factory", function () {
         const gasLimit = 6000000;
         const args = [new U32Value(7)];
 
-        const token = new Token("NFT-123456", 1);
-        const transfer = new NextTokenTransfer(token, 1);
+        const token = new Token("NFT-123456", 1n);
+        const transfer = new NextTokenTransfer(token, 1n);
 
         const transaction = smartContractFactory.createTransactionForExecute({
             sender: sender,
@@ -274,10 +274,10 @@ describe("test smart contract transactions factory", function () {
         const gasLimit = 6000000;
         const args = [new U32Value(7)];
 
-        const firstToken = new Token("NFT-123456", 1);
-        const firstTransfer = new NextTokenTransfer(firstToken, 1);
-        const secondToken = new Token("NFT-123456", 42);
-        const secondTransfer = new NextTokenTransfer(secondToken, 1);
+        const firstToken = new Token("NFT-123456", 1n);
+        const firstTransfer = new NextTokenTransfer(firstToken, 1n);
+        const secondToken = new Token("NFT-123456", 42n);
+        const secondTransfer = new NextTokenTransfer(secondToken, 1n);
 
         const transaction = smartContractFactory.createTransactionForExecute({
             sender: sender,

--- a/src/transactionsFactories/tokenTransfersDataBuilder.ts
+++ b/src/transactionsFactories/tokenTransfersDataBuilder.ts
@@ -1,6 +1,6 @@
 import { IAddress } from "../interface";
 import { NextTokenTransfer, TokenComputer } from "../tokens";
-import { numberToPaddedHex, utf8ToHex, addressToHex } from "../utils.codec";
+import { addressToHex, numberToPaddedHex, utf8ToHex } from "../utils.codec";
 
 export class TokenTransfersDataBuilder {
     private tokenComputer: TokenComputer;

--- a/src/transactionsFactories/transferTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/transferTransactionsFactory.spec.ts
@@ -1,9 +1,9 @@
 import { assert } from "chai";
 import { Address } from "../address";
-import { Token, NextTokenTransfer, TokenComputer } from "../tokens";
+import { ErrBadUsage } from "../errors";
+import { NextTokenTransfer, Token, TokenComputer } from "../tokens";
 import { TransactionsFactoryConfig } from "./transactionsFactoryConfig";
 import { NextTransferTransactionsFactory } from "./transferTransactionsFactory";
-import { ErrBadUsage } from "../errors";
 
 describe("test transfer transcations factory", function () {
     const config = new TransactionsFactoryConfig("D");
@@ -58,8 +58,8 @@ describe("test transfer transcations factory", function () {
     });
 
     it("should create 'TransactionNext' for esdt transfer", async () => {
-        const fooToken = new Token("FOO-123456", 0);
-        const transfer = new NextTokenTransfer(fooToken, 1000000);
+        const fooToken = new Token("FOO-123456", 0n);
+        const transfer = new NextTokenTransfer(fooToken, 1000000n);
 
         const transaction = nextTransferFactory.createTransactionForESDTTokenTransfer({
             sender: alice,
@@ -75,8 +75,8 @@ describe("test transfer transcations factory", function () {
     });
 
     it("should create 'TransactionNext' for nft transfer", async () => {
-        const nft = new Token("NFT-123456", 10);
-        const transfer = new NextTokenTransfer(nft, 1);
+        const nft = new Token("NFT-123456", 10n);
+        const transfer = new NextTokenTransfer(nft, 1n);
 
         const transaction = nextTransferFactory.createTransactionForESDTTokenTransfer({
             sender: alice,
@@ -95,11 +95,11 @@ describe("test transfer transcations factory", function () {
     });
 
     it("should create 'TransactionNext' for multiple nft transfers", async () => {
-        const firstNft = new Token("NFT-123456", 10);
-        const firstTransfer = new NextTokenTransfer(firstNft, 1);
+        const firstNft = new Token("NFT-123456", 10n);
+        const firstTransfer = new NextTokenTransfer(firstNft, 1n);
 
-        const secondNft = new Token("TEST-987654", 1);
-        const secondTransfer = new NextTokenTransfer(secondNft, 1);
+        const secondNft = new Token("TEST-987654", 1n);
+        const secondTransfer = new NextTokenTransfer(secondNft, 1n);
 
         const transaction = nextTransferFactory.createTransactionForESDTTokenTransfer({
             sender: alice,

--- a/src/utils.codec.spec.ts
+++ b/src/utils.codec.spec.ts
@@ -1,11 +1,19 @@
 import { assert } from "chai";
-import { isPaddedHex, numberToPaddedHex, zeroPadStringIfOddLength, byteArrayToHex, utf8ToHex } from "./utils.codec";
+import { byteArrayToHex, isPaddedHex, numberToPaddedHex, utf8ToHex, zeroPadStringIfOddLength } from "./utils.codec";
 
 describe("test codec utils", () => {
     it("should convert numberToPaddedHex", () => {
         assert.equal(numberToPaddedHex(1), "01");
         assert.equal(numberToPaddedHex(10), "0a");
         assert.equal(numberToPaddedHex(256), "0100");
+
+        assert.equal(numberToPaddedHex(1n), "01");
+        assert.equal(numberToPaddedHex(10n), "0a");
+        assert.equal(numberToPaddedHex(256n), "0100");
+
+        assert.equal(numberToPaddedHex("1"), "01");
+        assert.equal(numberToPaddedHex("10"), "0a");
+        assert.equal(numberToPaddedHex("256"), "0100");
     });
 
     it("should check if isPaddedHex", () => {

--- a/src/utils.codec.ts
+++ b/src/utils.codec.ts
@@ -1,10 +1,18 @@
 import BigNumber from "bignumber.js";
-import * as contractsCodecUtils from "./smartcontracts/codec/utils";
 import { Address } from "./address";
 import { IAddress } from "./interface";
+import * as contractsCodecUtils from "./smartcontracts/codec/utils";
 
-export function numberToPaddedHex(value: BigNumber.Value) {
-    let hex = new BigNumber(value).toString(16);
+export function numberToPaddedHex(value: bigint | number | BigNumber.Value) {
+    let hexableNumber: { toString(radix?: number): string };
+
+    if (typeof value === "bigint" || typeof value === "number") {
+        hexableNumber = value;
+    } else {
+        hexableNumber = new BigNumber(value);
+    }
+
+    const hex = hexableNumber.toString(16);
     return zeroPadStringIfOddLength(hex);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "module": "CommonJS",
-        "target": "es2015",
+        "target": "ES2020",
         "outDir": "out",
         "lib": [
-            "ES2015",
+            "ES2020",
             "DOM"
         ],
         "sourceMap": true,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "module": "CommonJS",
-        "target": "ES2015",
+        "target": "ES2020",
         "outDir": "out-tests",
         "lib": [
-            "ES2015",
+            "ES2020",
             "DOM"
         ],
         "sourceMap": true,


### PR DESCRIPTION
 - `compilerOptions`: for `target`, use ES2020 instead of ES2015.
 - partially replace `BigNumber.Value` with `bigint` (on some components that are new in v13)

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt