### PR TITLE
Address wrt. specs (partially). Additional minor breaking changes.

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -8,7 +8,7 @@ export class Account {
     /**
      * The address of the account.
      */
-    readonly address: IAddress = new Address();
+    readonly address: IAddress = Address.empty();
 
     /**
      * The nonce of the account (the account sequence number).

--- a/src/address.spec.ts
+++ b/src/address.spec.ts
@@ -17,7 +17,7 @@ describe("test address", () => {
     });
 
     it("should create empty address", async () => {
-        let nobody = new Address();
+        const nobody = Address.empty();
 
         assert.isEmpty(nobody.hex());
         assert.isEmpty(nobody.bech32());

--- a/src/address.spec.ts
+++ b/src/address.spec.ts
@@ -55,4 +55,16 @@ describe("test address", () => {
         assert.isFalse(Address.isValid("xerd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz"));
         assert.isFalse(Address.isValid("erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2"));
     });
+
+    it("should check whether isSmartContract", () => {
+        assert.isFalse(
+            Address.fromBech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th").isSmartContract(),
+        );
+        assert.isTrue(
+            Address.fromBech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l").isSmartContract(),
+        );
+        assert.isTrue(
+            Address.fromBech32("erd1qqqqqqqqqqqqqpgqxwakt2g7u9atsnr03gqcgmhcv38pt7mkd94q6shuwt").isSmartContract(),
+        );
+    });
 });

--- a/src/address.ts
+++ b/src/address.ts
@@ -138,9 +138,16 @@ export class Address {
     }
 
     /**
-     * Returns the hex representation of the address (pubkey)
+     * Use {@link toHex} instead.
      */
     hex(): string {
+        return this.toHex();
+    }
+
+    /**
+     * Returns the hex representation of the address (pubkey)
+     */
+    toHex(): string {
         if (this.isEmpty()) {
             return "";
         }
@@ -149,9 +156,16 @@ export class Address {
     }
 
     /**
-     * Returns the bech32 representation of the address
+     * Use {@link toBech32} instead.
      */
     bech32(): string {
+        return this.toBech32();
+    }
+
+    /**
+     * Returns the bech32 representation of the address
+     */
+    toBech32(): string {
         if (this.isEmpty()) {
             return "";
         }
@@ -162,9 +176,16 @@ export class Address {
     }
 
     /**
-     * Returns the pubkey as raw bytes (buffer)
+     * Use {@link getPublicKey} instead.
      */
     pubkey(): Buffer {
+        return this.getPublicKey();
+    }
+
+    /**
+     * Returns the pubkey as raw bytes (buffer)
+     */
+    getPublicKey(): Buffer {
         if (this.isEmpty()) {
             return Buffer.from([]);
         }
@@ -214,7 +235,17 @@ export class Address {
         return new Address("0".repeat(64));
     }
 
+    /**
+     * Use {@link isSmartContract} instead.
+     */
     isContractAddress(): boolean {
         return this.hex().startsWith(SMART_CONTRACT_HEX_PUBKEY_PREFIX);
+    }
+
+    /**
+     * Returns whether the address is a smart contract address.
+     */
+    isSmartContract(): boolean {
+        return this.isContractAddress();
     }
 }

--- a/src/address.ts
+++ b/src/address.ts
@@ -23,7 +23,7 @@ export class Address {
     /**
      * Creates an address object, given a raw string (whether a hex pubkey or a Bech32 address), a sequence of bytes, or another Address object.
      */
-    public constructor(value?: Address | Buffer | string) {
+    public constructor(value: Address | Buffer | string) {
         if (!value) {
             return;
         }
@@ -48,7 +48,7 @@ export class Address {
     }
 
     private static fromValidHex(value: string): Address {
-        let result = new Address();
+        let result = Address.empty();
         result.valueHex = value;
         return result;
     }
@@ -91,10 +91,10 @@ export class Address {
     }
 
     /**
-     * Creates an empty address object
+     * Creates an empty address object. Generally speaking, this should not be used in client code (internal use only).
      */
     static empty(): Address {
-        return new Address();
+        return new Address("");
     }
 
     /**

--- a/src/address.ts
+++ b/src/address.ts
@@ -91,7 +91,8 @@ export class Address {
     }
 
     /**
-     * Creates an empty address object. Generally speaking, this should not be used in client code (internal use only).
+     * Creates an empty address object.
+     * Generally speaking, this should not be used by client code (internal use only).
      */
     static empty(): Address {
         return new Address("");
@@ -229,7 +230,8 @@ export class Address {
     }
 
     /**
-     * Creates the Zero address (the one that should be used when deploying smart contracts)
+     * Creates the Zero address (the one that should be used when deploying smart contracts).
+     * Generally speaking, this should not be used by client code (internal use only).
      */
     static Zero(): Address {
         return new Address("0".repeat(64));

--- a/src/address.ts
+++ b/src/address.ts
@@ -110,12 +110,12 @@ export class Address {
             throw new errors.ErrAddressCannotCreate(value, err);
         }
 
-        let prefix = decoded.prefix;
+        const prefix = decoded.prefix;
         if (prefix != HRP) {
             throw new errors.ErrAddressBadHrp(HRP, prefix);
         }
 
-        let pubkey = Buffer.from(bech32.fromWords(decoded.words));
+        const pubkey = Buffer.from(bech32.fromWords(decoded.words));
         if (pubkey.length != PUBKEY_LENGTH) {
             throw new errors.ErrAddressCannotCreate(value);
         }
@@ -195,6 +195,14 @@ export class Address {
     }
 
     /**
+     * Returns the human-readable-part of the bech32 addresses.
+     * The HRP is currently hardcoded to "erd".
+     */
+    getHrp(): string {
+        return HRP;
+    }
+
+    /**
      * Returns whether the address is empty.
      */
     isEmpty() {
@@ -216,7 +224,7 @@ export class Address {
      * Returns the bech32 representation of the address
      */
     toString(): string {
-        return this.bech32();
+        return this.toBech32();
     }
 
     /**
@@ -224,8 +232,8 @@ export class Address {
      */
     toJSON(): object {
         return {
-            bech32: this.bech32(),
-            pubkey: this.hex(),
+            bech32: this.toBech32(),
+            pubkey: this.toHex(),
         };
     }
 
@@ -241,13 +249,13 @@ export class Address {
      * Use {@link isSmartContract} instead.
      */
     isContractAddress(): boolean {
-        return this.hex().startsWith(SMART_CONTRACT_HEX_PUBKEY_PREFIX);
+        return this.isSmartContract();
     }
 
     /**
      * Returns whether the address is a smart contract address.
      */
     isSmartContract(): boolean {
-        return this.isContractAddress();
+        return this.toHex().startsWith(SMART_CONTRACT_HEX_PUBKEY_PREFIX);
     }
 }

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -1,26 +1,21 @@
 import { Address } from "./address";
+import { Err } from "./errors";
 import { IAddress } from "./interface";
 
 /**
  * For internal use only.
  */
 export class Compatibility {
-    static areWarningsEnabled: boolean = true;
-
     /**
      * For internal use only.
      */
     static guardAddressIsSetAndNonZero(address: IAddress | undefined, context: string, resolution: string) {
-        if (!this.areWarningsEnabled) {
-            return;
-        }
-
         if (!address || address.bech32() == "") {
-            console.warn(
+            throw new Err(
                 `${context}: address should be set; ${resolution}. In the future, this will throw an exception instead of emitting a WARN.`,
             );
         } else if (address.bech32() == Address.Zero().bech32()) {
-            console.warn(
+            throw new Err(
                 `${context}: address should not be the 'zero' address (also known as the 'contracts deployment address'); ${resolution}. In the future, this will throw an exception instead of emitting a WARN.`,
             );
         }

--- a/src/signableMessage.ts
+++ b/src/signableMessage.ts
@@ -36,7 +36,7 @@ export class SignableMessage {
     this.signature = Buffer.from([]);
     this.version = 1;
     this.signer = "ErdJS";
-    this.address = new Address();
+    this.address = Address.empty();
 
     Object.assign(this, init);
   }

--- a/src/smartcontracts/interaction.ts
+++ b/src/smartcontracts/interaction.ts
@@ -35,9 +35,9 @@ export class Interaction {
     private gasLimit: IGasLimit = 0;
     private gasPrice: IGasPrice | undefined = undefined;
     private chainID: IChainID = "";
-    private querent: IAddress = new Address();
+    private querent: IAddress = Address.empty();
     private explicitReceiver?: IAddress;
-    private sender: IAddress = new Address();
+    private sender: IAddress = Address.empty();
 
     private isWithSingleESDTTransfer: boolean = false;
     private isWithSingleESDTNFTTransfer: boolean = false;

--- a/src/smartcontracts/query.ts
+++ b/src/smartcontracts/query.ts
@@ -18,7 +18,7 @@ export class Query {
         args?: TypedValue[],
         value?: ITransactionValue
     }) {
-        this.caller = obj.caller || new Address();
+        this.caller = obj.caller || Address.empty();
         this.address = obj.address;
         this.func = obj.func;
         this.args = obj.args || [];

--- a/src/smartcontracts/resultsParser.spec.ts
+++ b/src/smartcontracts/resultsParser.spec.ts
@@ -202,7 +202,7 @@ describe("test smart contract results parser", () => {
     it("should parse contract outcome, on signal error", async () => {
         let transaction = new TransactionOnNetwork({
             logs: new TransactionLogs({
-                address: new Address(),
+                address: Address.empty(),
                 events: [
                     new TransactionEvent({
                         identifier: "signalError",
@@ -222,7 +222,7 @@ describe("test smart contract results parser", () => {
     it("should parse contract outcome, on too much gas warning", async () => {
         let transaction = new TransactionOnNetwork({
             logs: new TransactionLogs({
-                address: new Address(),
+                address: Address.empty(),
                 events: [
                     new TransactionEvent({
                         identifier: "writeLog",

--- a/src/smartcontracts/smartContract.ts
+++ b/src/smartcontracts/smartContract.ts
@@ -31,7 +31,7 @@ interface IAbi {
  * An abstraction for deploying and interacting with Smart Contracts.
  */
 export class SmartContract implements ISmartContract {
-    private address: IAddress = new Address();
+    private address: IAddress = Address.empty();
     private abi?: IAbi;
 
     /**
@@ -53,7 +53,7 @@ export class SmartContract implements ISmartContract {
      * Create a SmartContract object by providing its address on the Network.
      */
     constructor(options: { address?: IAddress, abi?: IAbi } = {}) {
-        this.address = options.address || new Address();
+        this.address = options.address || Address.empty();
         this.abi = options.abi;
 
         if (this.abi) {

--- a/src/smartcontracts/transactionPayloadBuilders.ts
+++ b/src/smartcontracts/transactionPayloadBuilders.ts
@@ -7,10 +7,9 @@ import { TypedValue } from "./typesystem";
 export const WasmVirtualMachine = "0500";
 
 /**
- * A builder for {@link TransactionPayload} objects, to be used for Smart Contract deployment transactions.
- */
-/**
  * @deprecated Use {@link SmartContractTransactionsFactory} instead.
+ *
+ * A builder for {@link TransactionPayload} objects, to be used for Smart Contract deployment transactions.
  */
 export class ContractDeployPayloadBuilder {
     private code: ICode | null = null;
@@ -65,6 +64,8 @@ export class ContractDeployPayloadBuilder {
 }
 
 /**
+ * @deprecated Use {@link SmartContractTransactionsFactory} instead.
+ *
  * A builder for {@link TransactionPayload} objects, to be used for Smart Contract upgrade transactions.
  */
 export class ContractUpgradePayloadBuilder {
@@ -120,6 +121,8 @@ export class ContractUpgradePayloadBuilder {
 }
 
 /**
+ * @deprecated Use {@link SmartContractTransactionsFactory} instead.
+ *
  * A builder for {@link TransactionPayload} objects, to be used for Smart Contract execution transactions.
  */
 export class ContractCallPayloadBuilder {


### PR DESCRIPTION
 - Add extra methods on `Address`, wrt. specs: https://github.com/multiversx/mx-sdk-specs/blob/main/sdk-core/address.md
 - **Breaking change:** `Address` constructor cannot be called without parameters anymore. Replacement: `Address.empty()`. However, generally speaking, `new Address(/no params/)` should have never been used within client code. Just the same, `Address.empty()` should not be used by client code (internal use only).
 - **Breaking change (fixing change):** when address is required, but detected to be empty (or zero), an error is thrown (instead of just displaying a WARN). E.g. `interaction.buildTransaction()` will throw if `withSender()` wasn't called. The WARN was on ~1 year.