### PR TITLE
Changed the constructor of TransactionFactoryConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.0.0-beta.2",
+  "version": "13.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "13.0.0-beta.2",
+      "version": "13.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.0.0-beta.2",
+  "version": "13.0.0-beta.3",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/smartcontracts/smartContract.local.net.spec.ts
+++ b/src/smartcontracts/smartContract.local.net.spec.ts
@@ -341,7 +341,7 @@ describe("test on local testnet", function () {
         await alice.sync(provider);
 
         const transactionComputer = new TransactionComputer();
-        const config = new TransactionsFactoryConfig(network.ChainID);
+        const config = new TransactionsFactoryConfig({ chainID: network.ChainID });
         const factory = new SmartContractTransactionsFactory({ config: config, tokenComputer: new TokenComputer() });
 
         let bytecode = await promises.readFile("src/testdata/counter.wasm");

--- a/src/smartcontracts/smartContract.ts
+++ b/src/smartcontracts/smartContract.ts
@@ -117,7 +117,7 @@ export class SmartContract implements ISmartContract {
     deploy({ deployer, code, codeMetadata, initArguments, value, gasLimit, gasPrice, chainID }: DeployArguments): Transaction {
         Compatibility.guardAddressIsSetAndNonZero(deployer, "'deployer' of SmartContract.deploy()", "pass the actual address to deploy()");
 
-        const config = new TransactionsFactoryConfig(chainID.valueOf());
+        const config = new TransactionsFactoryConfig({ chainID: chainID.valueOf() });
         const scNextTransactionFactory = new SmartContractTransactionsFactory({
             config: config,
             abi: this.abi,
@@ -177,7 +177,7 @@ export class SmartContract implements ISmartContract {
 
         this.ensureHasAddress();
 
-        const config = new TransactionsFactoryConfig(chainID.valueOf());
+        const config = new TransactionsFactoryConfig({ chainID: chainID.valueOf() });
         const scNextTransactionFactory = new SmartContractTransactionsFactory({
             config: config,
             abi: this.abi,
@@ -215,7 +215,7 @@ export class SmartContract implements ISmartContract {
 
         this.ensureHasAddress();
 
-        const config = new TransactionsFactoryConfig(chainID.valueOf());
+        const config = new TransactionsFactoryConfig({ chainID: chainID.valueOf() });
         const scNextTransactionFactory = new SmartContractTransactionsFactory({
             config: config,
             abi: this.abi,

--- a/src/transaction.local.net.spec.ts
+++ b/src/transaction.local.net.spec.ts
@@ -151,7 +151,7 @@ describe("test transaction", function () {
 
         const network = await provider.getNetworkConfig();
 
-        const config = new TransactionsFactoryConfig(network.ChainID);
+        const config = new TransactionsFactoryConfig({ chainID: network.ChainID });
         const factory = new NextTransferTransactionsFactory(config, new TokenComputer());
 
         await alice.sync(provider);

--- a/src/transactionsFactories/delegationTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/delegationTransactionsFactory.spec.ts
@@ -6,7 +6,7 @@ import { ValidatorPublicKey } from "@multiversx/sdk-wallet";
 import { TransactionsFactoryConfig } from "./transactionsFactoryConfig";
 
 describe("test delegation transactions factory", function () {
-    const config = new TransactionsFactoryConfig("D");
+    const config = new TransactionsFactoryConfig({ chainID: "D" });
     const delegationFactory = new DelegationTransactionsFactory(config);
 
     it("should create 'TransactionNext' for new delegation contract", async function () {

--- a/src/transactionsFactories/relayedTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/relayedTransactionsFactory.spec.ts
@@ -5,7 +5,7 @@ import { RelayedTransactionsFactory } from "./relayedTransactionsFactory";
 import { TransactionsFactoryConfig } from "./transactionsFactoryConfig";
 
 describe("test relayed v1 transaction builder", function () {
-    const config = new TransactionsFactoryConfig("T");
+    const config = new TransactionsFactoryConfig({ chainID: "T" });
     const factory = new RelayedTransactionsFactory(config);
     const transactionComputer = new TransactionComputer();
     let alice: TestWallet, bob: TestWallet, carol: TestWallet, grace: TestWallet, frank: TestWallet;

--- a/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
@@ -11,7 +11,7 @@ import { SmartContractTransactionsFactory } from "./smartContractTransactionsFac
 import { TransactionsFactoryConfig } from "./transactionsFactoryConfig";
 
 describe("test smart contract transactions factory", function () {
-    const config = new TransactionsFactoryConfig("D");
+    const config = new TransactionsFactoryConfig({ chainID: "D" });
     let smartContractFactory: SmartContractTransactionsFactory;
     let abiAwareFactory: SmartContractTransactionsFactory;
     let adderByteCode: Code;

--- a/src/transactionsFactories/tokenManagementTransactionIntentsFactory.spec.ts
+++ b/src/transactionsFactories/tokenManagementTransactionIntentsFactory.spec.ts
@@ -11,7 +11,7 @@ describe("test token management transactions factory", () => {
 
     before(async function () {
         ({ frank, grace } = await loadTestWallets());
-        config = new TransactionsFactoryConfig("T");
+        config = new TransactionsFactoryConfig({ chainID: "T" });
         tokenManagementFactory = new TokenManagementTransactionsFactory(config);
     });
 

--- a/src/transactionsFactories/transactionsFactoryConfig.ts
+++ b/src/transactionsFactories/transactionsFactoryConfig.ts
@@ -30,9 +30,9 @@ export class TransactionsFactoryConfig {
     gasLimitESDTNFTTransfer: bigint;
     gasLimitMultiESDTNFTTransfer: bigint;
 
-    constructor(chainId: string) {
+    constructor(options: { chainID: string }) {
         // General-purpose configuration
-        this.chainID = chainId;
+        this.chainID = options.chainID;
         this.addressHrp = DEFAULT_HRP;
         this.minGasLimit = 50000n;
         this.gasLimitPerByte = 1500n;

--- a/src/transactionsFactories/transferTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/transferTransactionsFactory.spec.ts
@@ -6,7 +6,7 @@ import { TransactionsFactoryConfig } from "./transactionsFactoryConfig";
 import { NextTransferTransactionsFactory } from "./transferTransactionsFactory";
 
 describe("test transfer transcations factory", function () {
-    const config = new TransactionsFactoryConfig("D");
+    const config = new TransactionsFactoryConfig({ chainID: "D" });
     const nextTransferFactory = new NextTransferTransactionsFactory(config, new TokenComputer());
 
     const alice = Address.fromBech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");


### PR DESCRIPTION
The constructor of `TransactionFactoryConfig` used to need only one parameter, `chainId: string`. Now, it should receive a plain object of type:
```js
options: { chainID: string }
```

The name also changed, from `chainId` to `chainID` to be consistent since the member of the class is named `chainID`.