### PR TITLE
Refactor TransactionWatcher to accept either Transaction or hash

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,4 +16,4 @@ export const DEFAULT_HRP = "erd";
 export const ESDT_CONTRACT_ADDRESS = "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u";
 export const DEFAULT_MESSAGE_VERSION = 1;
 export const MESSAGE_PREFIX = "\x17Elrond Signed Message:\n";
-export const DEFALT_HEX_HASH_LENGTH = 64;
+export const DEFAULT_HEX_HASH_LENGTH = 64;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,3 +16,4 @@ export const DEFAULT_HRP = "erd";
 export const ESDT_CONTRACT_ADDRESS = "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u";
 export const DEFAULT_MESSAGE_VERSION = 1;
 export const MESSAGE_PREFIX = "\x17Elrond Signed Message:\n";
+export const DEFALT_HEX_HASH_LENGTH = 64;

--- a/src/transactionWatcher.spec.ts
+++ b/src/transactionWatcher.spec.ts
@@ -7,7 +7,7 @@ import { TransactionWatcher } from "./transactionWatcher";
 
 describe("test transactionWatcher", () => {
     it("should await status == executed using hash", async () => {
-        let hash = new TransactionHash("abba");
+        let hash = new TransactionHash("abbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabba");
         let provider = new MockNetworkProvider();
         let watcher = new TransactionWatcher(provider, {
             pollingIntervalMilliseconds: 42,
@@ -29,8 +29,8 @@ describe("test transactionWatcher", () => {
         assert.isTrue((await provider.getTransactionStatus(hash.hex())).isExecuted());
     });
 
-    it("should await status == executed using transction", async () => {
-        let hash = new TransactionHash("mockTransactionHash");
+    it("should await status == executed using transaction", async () => {
+        let hash = new TransactionHash("abbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabba");
         let provider = new MockNetworkProvider();
         let watcher = new TransactionWatcher(provider, {
             pollingIntervalMilliseconds: 42,

--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -1,5 +1,5 @@
 import { AsyncTimer } from "./asyncTimer";
-import { DEFALT_HEX_HASH_LENGTH } from "./constants";
+import { DEFAULT_HEX_HASH_LENGTH } from "./constants";
 import {
     Err,
     ErrExpectedTransactionEventsNotFound,
@@ -153,7 +153,7 @@ export class TransactionWatcher {
         const hash =
             typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
 
-        if (hash.length !== DEFALT_HEX_HASH_LENGTH) {
+        if (hash.length !== DEFAULT_HEX_HASH_LENGTH) {
             throw new Err("Invalid transaction hash length. The length of a hex encoded hash should be 64.");
         }
 

--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -1,4 +1,5 @@
 import { AsyncTimer } from "./asyncTimer";
+import { DEFALT_HEX_HASH_LENGTH } from "./constants";
 import {
     Err,
     ErrExpectedTransactionEventsNotFound,
@@ -149,7 +150,14 @@ export class TransactionWatcher {
     }
 
     private transactionOrTxHashToTxHash(transactionOrTxHash: ITransaction | string): string {
-        return typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+        const hash =
+            typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+
+        if (hash.length !== DEFALT_HEX_HASH_LENGTH) {
+            throw new Err("Invalid transaction hash length. The length of a hex encoded hash should be 64.");
+        }
+
+        return hash;
     }
 
     protected async awaitConditionally<TData>(

--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -64,7 +64,7 @@ export class TransactionWatcher {
     public async awaitPending(transactionOrTxHash: ITransaction | string): Promise<ITransactionOnNetwork> {
         const isPending = (transaction: ITransactionOnNetwork) => transaction.status.isPending();
         const doFetch = async () => {
-            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            const hash = this.transactionOrTxHashToTxHash(transactionOrTxHash);
             return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionStatusNotReached();
@@ -85,7 +85,7 @@ export class TransactionWatcher {
         };
 
         const doFetch = async () => {
-            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            const hash = this.transactionOrTxHashToTxHash(transactionOrTxHash);
             return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionStatusNotReached();
@@ -106,7 +106,7 @@ export class TransactionWatcher {
         };
 
         const doFetch = async () => {
-            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            const hash = this.transactionOrTxHashToTxHash(transactionOrTxHash);
             return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionEventsNotFound();
@@ -127,7 +127,7 @@ export class TransactionWatcher {
         };
 
         const doFetch = async () => {
-            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            const hash = this.transactionOrTxHashToTxHash(transactionOrTxHash);
             return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionEventsNotFound();
@@ -140,12 +140,16 @@ export class TransactionWatcher {
         condition: (data: ITransactionOnNetwork) => boolean,
     ): Promise<ITransactionOnNetwork> {
         const doFetch = async () => {
-            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            const hash = this.transactionOrTxHashToTxHash(transactionOrTxHash);
             return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionStatusNotReached();
 
         return this.awaitConditionally<ITransactionOnNetwork>(condition, doFetch, errorProvider);
+    }
+
+    private transactionOrTxHashToTxHash(transactionOrTxHash: ITransaction | string): string {
+        return typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
     }
 
     protected async awaitConditionally<TData>(

--- a/src/transactionWatcher.ts
+++ b/src/transactionWatcher.ts
@@ -64,10 +64,8 @@ export class TransactionWatcher {
     public async awaitPending(transactionOrTxHash: ITransaction | string): Promise<ITransactionOnNetwork> {
         const isPending = (transaction: ITransactionOnNetwork) => transaction.status.isPending();
         const doFetch = async () => {
-            if (typeof transactionOrTxHash === "string") {
-                return await this.fetcher.getTransaction(transactionOrTxHash);
-            }
-            return await this.fetcher.getTransaction(transactionOrTxHash.getHash().hex());
+            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionStatusNotReached();
 
@@ -87,10 +85,8 @@ export class TransactionWatcher {
         };
 
         const doFetch = async () => {
-            if (typeof transactionOrTxHash === "string") {
-                return await this.fetcher.getTransaction(transactionOrTxHash);
-            }
-            return await this.fetcher.getTransaction(transactionOrTxHash.getHash().hex());
+            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionStatusNotReached();
 
@@ -110,10 +106,8 @@ export class TransactionWatcher {
         };
 
         const doFetch = async () => {
-            if (typeof transactionOrTxHash === "string") {
-                return await this.fetcher.getTransaction(transactionOrTxHash);
-            }
-            return await this.fetcher.getTransaction(transactionOrTxHash.getHash().hex());
+            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionEventsNotFound();
 
@@ -133,10 +127,8 @@ export class TransactionWatcher {
         };
 
         const doFetch = async () => {
-            if (typeof transactionOrTxHash === "string") {
-                return await this.fetcher.getTransaction(transactionOrTxHash);
-            }
-            return await this.fetcher.getTransaction(transactionOrTxHash.getHash().hex());
+            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionEventsNotFound();
 
@@ -148,10 +140,8 @@ export class TransactionWatcher {
         condition: (data: ITransactionOnNetwork) => boolean,
     ): Promise<ITransactionOnNetwork> {
         const doFetch = async () => {
-            if (typeof transactionOrTxHash === "string") {
-                return await this.fetcher.getTransaction(transactionOrTxHash);
-            }
-            return await this.fetcher.getTransaction(transactionOrTxHash.getHash().hex());
+            const hash = typeof transactionOrTxHash === "string" ? transactionOrTxHash : transactionOrTxHash.getHash().hex();
+            return await this.fetcher.getTransaction(hash);
         };
         const errorProvider = () => new ErrExpectedTransactionStatusNotReached();
 


### PR DESCRIPTION
The methods of the `TransactionWatcher` can be called using either the transaction object or the hash of the transaction.

```js
public async awaitCompleted(transactionOrTxHash: ITransaction | string): Promise<ITransactionOnNetwork> {...}
```