### PR TITLE
More robust conversion of plain object to Transaction (same as v12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.0.0-beta.7",
+  "version": "13.0.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "13.0.0-beta.7",
+      "version": "13.0.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.0.0-beta.7",
+  "version": "13.0.0-beta.8",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/converters/transactionsConverter.ts
+++ b/src/converters/transactionsConverter.ts
@@ -45,8 +45,8 @@ export class TransactionsConverter {
             gasLimit: BigInt(object.gasLimit),
             data: this.bufferFromBase64(object.data),
             chainID: String(object.chainID),
-            version: object.version,
-            options: object.options,
+            version: Number(object.version),
+            options: Number(object.options),
             signature: this.bufferFromHex(object.signature),
             guardianSignature: this.bufferFromHex(object.guardianSignature),
         });


### PR DESCRIPTION
Undo regression (decrease of robustness) - cast options & versions to `number`.