### PR TITLE
Hotfix (regression): interaction (legacy API) with ABI, with transfers (transfer & execute)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.0.0-beta.11",
+  "version": "13.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "13.0.0-beta.11",
+      "version": "13.0.0-beta.12",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.0.0-beta.11",
+  "version": "13.0.0-beta.12",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -73,6 +73,9 @@ export interface ITransactionPayload {
     valueOf(): Buffer;
 }
 
+/**
+ * Legacy interface. The class `TokenTransfer` can be used instead, where necessary.
+ */
 export interface ITokenTransfer {
     readonly tokenIdentifier: string;
     readonly nonce: number;

--- a/src/smartcontracts/codec/binary.spec.ts
+++ b/src/smartcontracts/codec/binary.spec.ts
@@ -1,7 +1,7 @@
 import * as errors from "../../errors";
 import { assert } from "chai";
 import { BinaryCodec, BinaryCodecConstraints } from "./binary";
-import { AddressType, AddressValue, BigIntType, BigUIntType, BigUIntValue, BooleanType, BooleanValue, I16Type, I32Type, I64Type, I8Type, NumericalType, NumericalValue, Struct, Field, StructType, TypedValue, U16Type, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, List, ListType, EnumType, EnumVariantDefinition, EnumValue, ArrayVec, ArrayVecType, U16Value, TokenIdentifierType, TokenIdentifierValue, StringValue, StringType } from "../typesystem";
+import { AddressType, AddressValue, BigIntType, BigUIntType, BigUIntValue, BooleanType, BooleanValue, I16Type, I32Type, I64Type, I8Type, NumericalType, NumericalValue, Struct, Field, StructType, TypedValue, U16Type, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, List, ListType, EnumType, EnumVariantDefinition, EnumValue, ArrayVec, ArrayVecType, U16Value, TokenIdentifierType, TokenIdentifierValue, StringValue, StringType, BigIntValue, I64Value, I32Value, I16Value, I8Value } from "../typesystem";
 import { isMsbOne } from "./utils";
 import { Address } from "../../address";
 import { BytesType, BytesValue } from "../typesystem/bytes";
@@ -83,6 +83,20 @@ describe("test binary codec (basic)", () => {
             assert.instanceOf(decodedTop, NumericalValue);
             assert.isTrue(decodedTop.equals(value));
         }
+    });
+
+    it("should create numeric values, from both bigint and BigNumber.Value", async () => {
+        assert.deepEqual(new BigUIntValue("0xabcdefabcdefabcdef"), new BigUIntValue(BigInt("0xabcdefabcdefabcdef")));
+        assert.deepEqual(new U64Value("0xabcdef"), new U64Value(BigInt(0xabcdef)));
+        assert.deepEqual(new U32Value("0xabcdef"), new U32Value(BigInt(0xabcdef)));
+        assert.deepEqual(new U16Value("0xabcdef"), new U16Value(BigInt(0xabcdef)));
+        assert.deepEqual(new U8Value("0xabcdef"), new U8Value(BigInt(0xabcdef)));
+
+        assert.deepEqual(new BigIntValue(BigInt("0xabcdefabcdefabcdef")), new BigIntValue(BigInt("0xabcdefabcdefabcdef")));
+        assert.deepEqual(new I64Value("0xabcdef"), new I64Value(BigInt(0xabcdef)));
+        assert.deepEqual(new I32Value("0xabcdef"), new I32Value(BigInt(0xabcdef)));
+        assert.deepEqual(new I16Value("0xabcdef"), new I16Value(BigInt(0xabcdef)));
+        assert.deepEqual(new I8Value("0xabcdef"), new I8Value(BigInt(0xabcdef)));
     });
 
     it("should create bytes and strings, encode and decode", async () => {

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -175,7 +175,7 @@ describe("test smart contract interactor", function () {
                 data: Buffer.from("ESDTTransfer@464f4f2d616263646566@64@676574556c74696d617465416e73776572"),
                 gasLimit: 543210n,
                 value: 0n,
-                version: 1,
+                version: 2,
                 nonce: 42n,
             }),
         );
@@ -189,7 +189,7 @@ describe("test smart contract interactor", function () {
         let controller = new ContractController(provider);
 
         let interaction = <Interaction>(
-            contract.methods.getUltimateAnswer().withGasLimit(543210).withChainID("T").withVersion(2)
+            contract.methods.getUltimateAnswer().withGasLimit(543210).withChainID("T")
         );
 
         assert.equal(contract.getAddress(), dummyAddress);

--- a/src/smartcontracts/interaction.spec.ts
+++ b/src/smartcontracts/interaction.spec.ts
@@ -10,7 +10,8 @@ import {
     TestWallet
 } from "../testutils";
 import { ContractController } from "../testutils/contractController";
-import { TokenTransfer } from "../tokens";
+import { Token, TokenTransfer } from "../tokens";
+import { Transaction } from "../transaction";
 import { ContractFunction } from "./function";
 import { Interaction } from "./interaction";
 import { ReturnCode } from "./returnCode";
@@ -148,7 +149,36 @@ describe("test smart contract interactor", function () {
 
         assert.equal(transaction.getSender().bech32(), alice.bech32());
         assert.equal(transaction.getReceiver().bech32(), alice.bech32());
-        assert.equal(transaction.getData().toString(), `MultiESDTNFTTransfer@${hexContractAddress}@02@${hexStrămoși}@01@01@${hexStrămoși}@2a@01@${hexDummyFunction}`);
+    });
+
+    it("should create transaction, with ABI, with transfer & execute", async function () {
+        const abiRegistry = await loadAbiRegistry("src/testdata/answer.abi.json");
+        const contract = new SmartContract({ address: dummyAddress, abi: abiRegistry });
+        const alice = new Address("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+        const token = new Token({ identifier: "FOO-abcdef", nonce: 0n });
+
+        const transaction = contract.methods
+            .getUltimateAnswer()
+            .withChainID("T")
+            .withSender(alice)
+            .withGasLimit(543210)
+            .withSingleESDTTransfer(new TokenTransfer({ token, amount: 100n }))
+            .withNonce(42)
+            .buildTransaction();
+
+        assert.deepEqual(
+            transaction,
+            new Transaction({
+                chainID: "T",
+                sender: alice.toBech32(),
+                receiver: dummyAddress.toBech32(),
+                data: Buffer.from("ESDTTransfer@464f4f2d616263646566@64@676574556c74696d617465416e73776572"),
+                gasLimit: 543210n,
+                value: 0n,
+                version: 1,
+                nonce: 42n,
+            }),
+        );
     });
 
     it("should interact with 'answer'", async function () {
@@ -158,10 +188,9 @@ describe("test smart contract interactor", function () {
         let contract = new SmartContract({ address: dummyAddress, abi: abiRegistry });
         let controller = new ContractController(provider);
 
-        let interaction = <Interaction>contract.methods
-            .getUltimateAnswer()
-            .withGasLimit(543210)
-            .withChainID("T");
+        let interaction = <Interaction>(
+            contract.methods.getUltimateAnswer().withGasLimit(543210).withChainID("T").withVersion(2)
+        );
 
         assert.equal(contract.getAddress(), dummyAddress);
         assert.deepEqual(interaction.getFunction(), new ContractFunction("getUltimateAnswer"));

--- a/src/smartcontracts/interaction.ts
+++ b/src/smartcontracts/interaction.ts
@@ -1,14 +1,15 @@
 import { Account } from "../account";
 import { Address } from "../address";
 import { Compatibility } from "../compatibility";
-import { ESDTNFT_TRANSFER_FUNCTION_NAME, ESDT_TRANSFER_FUNCTION_NAME, MULTI_ESDTNFT_TRANSFER_FUNCTION_NAME } from "../constants";
 import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, ITokenTransfer, ITransactionValue } from "../interface";
+import { TokenComputer, TokenTransfer } from "../tokens";
 import { Transaction } from "../transaction";
+import { SmartContractTransactionsFactory, TransactionsFactoryConfig } from "../transactionsFactories";
 import { ContractFunction } from "./function";
 import { InteractionChecker } from "./interactionChecker";
 import { CallArguments } from "./interface";
 import { Query } from "./query";
-import { AddressValue, BigUIntValue, BytesValue, EndpointDefinition, TypedValue, U64Value, U8Value } from "./typesystem";
+import { EndpointDefinition, TypedValue } from "./typesystem";
 
 /**
  * Internal interface: the smart contract, as seen from the perspective of an {@link Interaction}.
@@ -20,8 +21,10 @@ interface ISmartContractWithinInteraction {
 }
 
 /**
+ * Legacy component. Use "SmartContractTransactionsFactory" (for transactions) or "SmartContractQueriesController" (for queries), instead.
+ *
  * Interactions can be seen as mutable transaction & query builders.
- * 
+ *
  * Aside from building transactions and queries, the interactors are also responsible for interpreting
  * the execution outcome for the objects they've built.
  */
@@ -39,10 +42,11 @@ export class Interaction {
     private explicitReceiver?: IAddress;
     private sender: IAddress = Address.empty();
 
-    private isWithSingleESDTTransfer: boolean = false;
-    private isWithSingleESDTNFTTransfer: boolean = false;
-    private isWithMultiESDTNFTTransfer: boolean = false;
-    private tokenTransfers: TokenTransfersWithinInteraction;
+    // When using the Interaction API, we use the legacy transaction version by default,
+    // in order to have as little impact as possible on a quick upgrade from v12 to v13.
+    private version: number = 1;
+
+    private tokenTransfers: TokenTransfer[];
 
     constructor(
         contract: ISmartContractWithinInteraction,
@@ -52,7 +56,7 @@ export class Interaction {
         this.contract = contract;
         this.function = func;
         this.args = args;
-        this.tokenTransfers = new TokenTransfersWithinInteraction([], this);
+        this.tokenTransfers = [];
     }
 
     getContractAddress(): IAddress {
@@ -76,7 +80,7 @@ export class Interaction {
     }
 
     getTokenTransfers(): ITokenTransfer[] {
-        return this.tokenTransfers.getTransfers();
+        return this.tokenTransfers;
     }
 
     getGasLimit(): IGasLimit {
@@ -90,39 +94,29 @@ export class Interaction {
     buildTransaction(): Transaction {
         Compatibility.guardAddressIsSetAndNonZero(this.sender, "'sender' of interaction", "use interaction.withSender()");
 
-        let receiver = this.explicitReceiver || this.contract.getAddress();
-        let func: ContractFunction = this.function;
-        let args = this.args;
-
-        if (this.isWithSingleESDTTransfer) {
-            func = new ContractFunction(ESDT_TRANSFER_FUNCTION_NAME);
-            args = this.tokenTransfers.buildArgsForSingleESDTTransfer();
-        } else if (this.isWithSingleESDTNFTTransfer) {
-            // For NFT, SFT and MetaESDT, transaction.sender == transaction.receiver.
-            receiver = this.sender;
-            func = new ContractFunction(ESDTNFT_TRANSFER_FUNCTION_NAME);
-            args = this.tokenTransfers.buildArgsForSingleESDTNFTTransfer();
-        } else if (this.isWithMultiESDTNFTTransfer) {
-            // For NFT, SFT and MetaESDT, transaction.sender == transaction.receiver.
-            receiver = this.sender;
-            func = new ContractFunction(MULTI_ESDTNFT_TRANSFER_FUNCTION_NAME);
-            args = this.tokenTransfers.buildArgsForMultiESDTNFTTransfer();
-        }
-
-        let transaction = this.contract.call({
-            func: func,
-            // GasLimit will be set using "withGasLimit()".
-            gasLimit: this.gasLimit,
-            gasPrice: this.gasPrice,
-            args: args,
-            // Value will be set using "withValue()".
-            value: this.value,
-            receiver: receiver,
-            chainID: this.chainID,
-            caller: this.sender
+        const factoryConfig = new TransactionsFactoryConfig({ chainID: this.chainID.valueOf() });
+        const factory = new SmartContractTransactionsFactory({
+            config: factoryConfig,
+            tokenComputer: new TokenComputer(),
         });
 
-        transaction.setNonce(this.nonce);
+        const transaction = factory.createTransactionForExecute({
+            sender: this.sender,
+            contract: this.contract.getAddress(),
+            functionName: this.function.valueOf(),
+            gasLimit: BigInt(this.gasLimit.valueOf()),
+            args: this.args,
+            nativeTransferAmount: BigInt(this.value.toString()),
+            tokenTransfers: this.tokenTransfers,
+        });
+
+        transaction.chainID = this.chainID.valueOf();
+        transaction.nonce = BigInt(this.nonce.valueOf());
+        transaction.version = this.version;
+
+        if (this.gasPrice) {
+            transaction.gasPrice = BigInt(this.gasPrice.valueOf());
+        }
 
         return transaction;
     }
@@ -134,7 +128,7 @@ export class Interaction {
             args: this.args,
             // Value will be set using "withValue()".
             value: this.value,
-            caller: this.querent
+            caller: this.querent,
         });
     }
 
@@ -144,24 +138,17 @@ export class Interaction {
     }
 
     withSingleESDTTransfer(transfer: ITokenTransfer): Interaction {
-        this.isWithSingleESDTTransfer = true;
-        this.tokenTransfers = new TokenTransfersWithinInteraction([transfer], this);
+        this.tokenTransfers = [transfer].map((transfer) => new TokenTransfer(transfer));
         return this;
     }
-
-    withSingleESDTNFTTransfer(transfer: ITokenTransfer): Interaction;
 
     withSingleESDTNFTTransfer(transfer: ITokenTransfer): Interaction {
-        this.isWithSingleESDTNFTTransfer = true;
-        this.tokenTransfers = new TokenTransfersWithinInteraction([transfer], this);
+        this.tokenTransfers = [transfer].map((transfer) => new TokenTransfer(transfer));
         return this;
     }
 
-    withMultiESDTNFTTransfer(transfers: ITokenTransfer[]): Interaction;
-
     withMultiESDTNFTTransfer(transfers: ITokenTransfer[]): Interaction {
-        this.isWithMultiESDTNFTTransfer = true;
-        this.tokenTransfers = new TokenTransfersWithinInteraction(transfers, this);
+        this.tokenTransfers = transfers.map((transfer) => new TokenTransfer(transfer));
         return this;
     }
 
@@ -194,6 +181,11 @@ export class Interaction {
         return this;
     }
 
+    withVersion(version: number): Interaction {
+        this.version = version;
+        return this;
+    }
+
     /**
      * Sets the "caller" field on contract queries.
      */
@@ -213,94 +205,5 @@ export class Interaction {
     check(): Interaction {
         new InteractionChecker().checkInteraction(this, this.getEndpoint());
         return this;
-    }
-}
-
-class TokenTransfersWithinInteraction {
-    private readonly transfers: ITokenTransfer[];
-    private readonly interaction: Interaction;
-
-    constructor(transfers: ITokenTransfer[], interaction: Interaction) {
-        this.transfers = transfers;
-        this.interaction = interaction;
-    }
-
-    getTransfers() {
-        return this.transfers;
-    }
-
-    buildArgsForSingleESDTTransfer(): TypedValue[] {
-        let singleTransfer = this.transfers[0];
-
-        return [
-            this.getTypedTokenIdentifier(singleTransfer),
-            this.getTypedTokenQuantity(singleTransfer),
-            this.getTypedInteractionFunction(),
-            ...this.getInteractionArguments()
-        ];
-    }
-
-    buildArgsForSingleESDTNFTTransfer(): TypedValue[] {
-        let singleTransfer = this.transfers[0];
-
-        return [
-            this.getTypedTokenIdentifier(singleTransfer),
-            this.getTypedTokenNonce(singleTransfer),
-            this.getTypedTokenQuantity(singleTransfer),
-            this.getTypedTokensReceiver(),
-            this.getTypedInteractionFunction(),
-            ...this.getInteractionArguments()
-        ];
-    }
-
-    buildArgsForMultiESDTNFTTransfer(): TypedValue[] {
-        let result: TypedValue[] = [];
-
-        result.push(this.getTypedTokensReceiver());
-        result.push(this.getTypedNumberOfTransfers());
-
-        for (const transfer of this.transfers) {
-            result.push(this.getTypedTokenIdentifier(transfer));
-            result.push(this.getTypedTokenNonce(transfer));
-            result.push(this.getTypedTokenQuantity(transfer));
-        }
-
-        result.push(this.getTypedInteractionFunction());
-        result.push(...this.getInteractionArguments());
-
-        return result;
-    }
-
-    private getTypedNumberOfTransfers(): TypedValue {
-        return new U8Value(this.transfers.length);
-    }
-
-    private getTypedTokenIdentifier(transfer: ITokenTransfer): TypedValue {
-        // Important: for NFTs, this has to be the "collection" name, actually.
-        // We will reconsider adding the field "collection" on "Token" upon merging "ApiProvider" and "ProxyProvider".
-        return BytesValue.fromUTF8(transfer.tokenIdentifier);
-    }
-
-    private getTypedTokenNonce(transfer: ITokenTransfer): TypedValue {
-        // The token nonce (creation nonce)
-        return new U64Value(transfer.nonce);
-    }
-
-    private getTypedTokenQuantity(transfer: ITokenTransfer): TypedValue {
-        // For NFTs, this will be 1.
-        return new BigUIntValue(transfer.amountAsBigInteger);
-    }
-
-    private getTypedTokensReceiver(): TypedValue {
-        // The actual receiver of the token(s): the contract
-        return new AddressValue(this.interaction.getContractAddress());
-    }
-
-    private getTypedInteractionFunction(): TypedValue {
-        return BytesValue.fromUTF8(this.interaction.getFunction().valueOf())
-    }
-
-    private getInteractionArguments(): TypedValue[] {
-        return this.interaction.getArguments();
     }
 }

--- a/src/smartcontracts/interaction.ts
+++ b/src/smartcontracts/interaction.ts
@@ -1,6 +1,7 @@
 import { Account } from "../account";
 import { Address } from "../address";
 import { Compatibility } from "../compatibility";
+import { TRANSACTION_VERSION_DEFAULT } from "../constants";
 import { IAddress, IChainID, IGasLimit, IGasPrice, INonce, ITokenTransfer, ITransactionValue } from "../interface";
 import { TokenComputer, TokenTransfer } from "../tokens";
 import { Transaction } from "../transaction";
@@ -41,10 +42,7 @@ export class Interaction {
     private querent: IAddress = Address.empty();
     private explicitReceiver?: IAddress;
     private sender: IAddress = Address.empty();
-
-    // When using the Interaction API, we use the legacy transaction version by default,
-    // in order to have as little impact as possible on a quick upgrade from v12 to v13.
-    private version: number = 1;
+    private version: number = TRANSACTION_VERSION_DEFAULT;
 
     private tokenTransfers: TokenTransfer[];
 

--- a/src/smartcontracts/typesystem/numerical.ts
+++ b/src/smartcontracts/typesystem/numerical.ts
@@ -156,8 +156,12 @@ export class NumericalValue extends PrimitiveValue {
     readonly sizeInBytes: number | undefined;
     readonly withSign: boolean;
 
-    constructor(type: NumericalType, value: BigNumber.Value) {
+    constructor(type: NumericalType, value: BigNumber.Value | bigint) {
         super(type);
+
+        if (typeof value === "bigint") {
+            value = value.toString();
+        }
 
         this.value = new BigNumber(value);
         this.sizeInBytes = type.sizeInBytes;
@@ -178,7 +182,7 @@ export class NumericalValue extends PrimitiveValue {
 
     /**
      * Returns whether two objects have the same value.
-     * 
+     *
      * @param other another NumericalValue
      */
     equals(other: NumericalValue): boolean {
@@ -197,8 +201,8 @@ export class NumericalValue extends PrimitiveValue {
 export class U8Value extends NumericalValue {
     static ClassName = "U8Value";
 
-    constructor(value: BigNumber.Value) {
-        super(new U8Type(), new BigNumber(value));
+    constructor(value: BigNumber.Value | bigint) {
+        super(new U8Type(), value);
     }
 
     getClassName(): string {
@@ -209,8 +213,8 @@ export class U8Value extends NumericalValue {
 export class I8Value extends NumericalValue {
     static ClassName = "I8Value";
 
-    constructor(value: BigNumber.Value) {
-        super(new I8Type(), new BigNumber(value));
+    constructor(value: BigNumber.Value | bigint) {
+        super(new I8Type(), value);
     }
 
     getClassName(): string {
@@ -221,8 +225,8 @@ export class I8Value extends NumericalValue {
 export class U16Value extends NumericalValue {
     static ClassName = "U16Value";
 
-    constructor(value: BigNumber.Value) {
-        super(new U16Type(), new BigNumber(value));
+    constructor(value: BigNumber.Value | bigint) {
+        super(new U16Type(), value);
     }
 
     getClassName(): string {
@@ -233,8 +237,8 @@ export class U16Value extends NumericalValue {
 export class I16Value extends NumericalValue {
     static ClassName = "I16Value";
 
-    constructor(value: BigNumber.Value) {
-        super(new I16Type(), new BigNumber(value));
+    constructor(value: BigNumber.Value | bigint) {
+        super(new I16Type(), value);
     }
 
     getClassName(): string {
@@ -245,8 +249,8 @@ export class I16Value extends NumericalValue {
 export class U32Value extends NumericalValue {
     static ClassName = "U32Value";
 
-    constructor(value: BigNumber.Value) {
-        super(new U32Type(), new BigNumber(value));
+    constructor(value: BigNumber.Value | bigint) {
+        super(new U32Type(), value);
     }
 
     getClassName(): string {
@@ -257,8 +261,8 @@ export class U32Value extends NumericalValue {
 export class I32Value extends NumericalValue {
     static ClassName = "I32Value";
 
-    constructor(value: BigNumber.Value) {
-        super(new I32Type(), new BigNumber(value));
+    constructor(value: BigNumber.Value | bigint) {
+        super(new I32Type(), value);
     }
 
     getClassName(): string {
@@ -269,7 +273,7 @@ export class I32Value extends NumericalValue {
 export class U64Value extends NumericalValue {
     static ClassName = "U64Value";
 
-    constructor(value: BigNumber.Value) {
+    constructor(value: BigNumber.Value | bigint) {
         super(new U64Type(), value);
     }
 
@@ -281,7 +285,7 @@ export class U64Value extends NumericalValue {
 export class I64Value extends NumericalValue {
     static ClassName = "I64Value";
 
-    constructor(value: BigNumber.Value) {
+    constructor(value: BigNumber.Value | bigint) {
         super(new I64Type(), value);
     }
 
@@ -293,7 +297,7 @@ export class I64Value extends NumericalValue {
 export class BigUIntValue extends NumericalValue {
     static ClassName = "BigUIntValue";
 
-    constructor(value: BigNumber.Value) {
+    constructor(value: BigNumber.Value | bigint) {
         super(new BigUIntType(), value);
     }
 
@@ -305,7 +309,7 @@ export class BigUIntValue extends NumericalValue {
 export class BigIntValue extends NumericalValue {
     static ClassName = "BigIntValue";
 
-    constructor(value: BigNumber.Value) {
+    constructor(value: BigNumber.Value | bigint) {
         super(new BigIntType(), value);
     }
 

--- a/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
@@ -217,7 +217,7 @@ describe("test smart contract transactions factory", function () {
         assert.deepEqual(
             transaction.data,
             Buffer.from(
-                "MultiESDTNFTTransfer@00000000000000000500ed8e25a94efa837aae0e593112cfbb01b448755069e1@02@464f4f2d366365313762@00@0a@4241522d356263303866@00@0c44@616464@07",
+                "MultiESDTNFTTransfer@00000000000000000500ed8e25a94efa837aae0e593112cfbb01b448755069e1@02@464f4f2d366365313762@@0a@4241522d356263303866@@0c44@616464@07",
             ),
         );
 

--- a/src/transactionsFactories/smartContractTransactionsFactory.ts
+++ b/src/transactionsFactories/smartContractTransactionsFactory.ts
@@ -100,13 +100,13 @@ export class SmartContractTransactionsFactory {
             const transfer = tokenTransfer[0];
 
             if (this.tokenComputer.isFungible(transfer.token)) {
-                dataParts = this.dataArgsBuilder.buildArgsForESDTTransfer(transfer);
+                dataParts = this.dataArgsBuilder.buildDataPartsForESDTTransfer(transfer);
             } else {
-                dataParts = this.dataArgsBuilder.buildArgsForSingleESDTNFTTransfer(transfer, receiver);
+                dataParts = this.dataArgsBuilder.buildDataPartsForSingleESDTNFTTransfer(transfer, receiver);
                 receiver = options.sender;
             }
         } else if (numberOfTokens > 1) {
-            dataParts = this.dataArgsBuilder.buildArgsForMultiESDTNFTTransfer(receiver, tokenTransfer);
+            dataParts = this.dataArgsBuilder.buildDataPartsForMultiESDTNFTTransfer(receiver, tokenTransfer);
             receiver = options.sender;
         }
 

--- a/src/transactionsFactories/tokenTransfersDataBuilder.ts
+++ b/src/transactionsFactories/tokenTransfersDataBuilder.ts
@@ -1,6 +1,6 @@
 import { IAddress } from "../interface";
 import { TokenComputer, TokenTransfer } from "../tokens";
-import { addressToHex, numberToPaddedHex, utf8ToHex } from "../utils.codec";
+import { addressToHex, numberToPaddedHex, numberToPaddedHexWithZeroAsEmptyString, utf8ToHex } from "../utils.codec";
 
 export class TokenTransfersDataBuilder {
     private tokenComputer: TokenComputer;
@@ -11,7 +11,7 @@ export class TokenTransfersDataBuilder {
 
     buildArgsForESDTTransfer(transfer: TokenTransfer): string[] {
         let args = ["ESDTTransfer"];
-        args.push(...[utf8ToHex(transfer.token.identifier), numberToPaddedHex(transfer.amount)]);
+        args.push(...[utf8ToHex(transfer.token.identifier), numberToPaddedHexWithZeroAsEmptyString(transfer.amount)]);
         return args;
     }
 
@@ -24,8 +24,8 @@ export class TokenTransfersDataBuilder {
         args.push(
             ...[
                 utf8ToHex(identifier),
-                numberToPaddedHex(token.nonce),
-                numberToPaddedHex(transfer.amount),
+                numberToPaddedHexWithZeroAsEmptyString(token.nonce),
+                numberToPaddedHexWithZeroAsEmptyString(transfer.amount),
                 addressToHex(receiver),
             ],
         );
@@ -38,7 +38,11 @@ export class TokenTransfersDataBuilder {
         for (let transfer of transfers) {
             const identifier = this.tokenComputer.extractIdentifierFromExtendedIdentifier(transfer.token.identifier);
             args.push(
-                ...[utf8ToHex(identifier), numberToPaddedHex(transfer.token.nonce), numberToPaddedHex(transfer.amount)],
+                ...[
+                    utf8ToHex(identifier),
+                    numberToPaddedHexWithZeroAsEmptyString(transfer.token.nonce),
+                    numberToPaddedHexWithZeroAsEmptyString(transfer.amount),
+                ],
             );
         }
 

--- a/src/transactionsFactories/tokenTransfersDataBuilder.ts
+++ b/src/transactionsFactories/tokenTransfersDataBuilder.ts
@@ -9,13 +9,13 @@ export class TokenTransfersDataBuilder {
         this.tokenComputer = new TokenComputer();
     }
 
-    buildArgsForESDTTransfer(transfer: TokenTransfer): string[] {
+    buildDataPartsForESDTTransfer(transfer: TokenTransfer): string[] {
         let args = ["ESDTTransfer"];
         args.push(...[utf8ToHex(transfer.token.identifier), numberToPaddedHexWithZeroAsEmptyString(transfer.amount)]);
         return args;
     }
 
-    buildArgsForSingleESDTNFTTransfer(transfer: TokenTransfer, receiver: IAddress) {
+    buildDataPartsForSingleESDTNFTTransfer(transfer: TokenTransfer, receiver: IAddress) {
         let args = ["ESDTNFTTransfer"];
 
         const token = transfer.token;
@@ -32,7 +32,7 @@ export class TokenTransfersDataBuilder {
         return args;
     }
 
-    buildArgsForMultiESDTNFTTransfer(receiver: IAddress, transfers: TokenTransfer[]) {
+    buildDataPartsForMultiESDTNFTTransfer(receiver: IAddress, transfers: TokenTransfer[]) {
         let args = ["MultiESDTNFTTransfer", addressToHex(receiver), numberToPaddedHex(transfers.length)];
 
         for (let transfer of transfers) {

--- a/src/transactionsFactories/transferTransactionsFactory.ts
+++ b/src/transactionsFactories/transferTransactionsFactory.ts
@@ -52,7 +52,7 @@ interface IGasEstimator {
  */
 export class TransferTransactionsFactory {
     private readonly config?: IConfig;
-    private readonly dataArgsBuilder?: TokenTransfersDataBuilder;
+    private readonly tokenTransfersDataBuilder?: TokenTransfersDataBuilder;
     private readonly tokenComputer?: ITokenComputer;
     private readonly gasEstimator?: IGasEstimator;
 
@@ -68,7 +68,7 @@ export class TransferTransactionsFactory {
         } else {
             this.config = options.config;
             this.tokenComputer = options.tokenComputer;
-            this.dataArgsBuilder = new TokenTransfersDataBuilder();
+            this.tokenTransfersDataBuilder = new TokenTransfersDataBuilder();
         }
     }
 
@@ -91,7 +91,7 @@ export class TransferTransactionsFactory {
             throw new Err("'config' is not defined");
         }
 
-        if (this.dataArgsBuilder === undefined) {
+        if (this.tokenTransfersDataBuilder === undefined) {
             throw new Err("`dataArgsBuilder is not defined`");
         }
 
@@ -138,7 +138,7 @@ export class TransferTransactionsFactory {
             return this.createSingleESDTTransferTransaction(options);
         }
 
-        const transferArgs = this.dataArgsBuilder!.buildArgsForMultiESDTNFTTransfer(
+        const dataParts = this.tokenTransfersDataBuilder!.buildDataPartsForMultiESDTNFTTransfer(
             options.receiver,
             options.tokenTransfers,
         );
@@ -151,7 +151,7 @@ export class TransferTransactionsFactory {
             config: this.config!,
             sender: options.sender,
             receiver: options.sender,
-            dataParts: transferArgs,
+            dataParts: dataParts,
             gasLimit: extraGasForTransfer,
             addDataMovementGas: true,
         }).build();
@@ -343,16 +343,16 @@ export class TransferTransactionsFactory {
     }): Transaction {
         this.ensureMembersAreDefined();
 
-        let transferArgs: string[] = [];
+        let dataParts: string[] = [];
         const transfer = options.tokenTransfers[0];
         let extraGasForTransfer = 0n;
         let receiver = options.receiver;
 
         if (this.tokenComputer!.isFungible(transfer.token)) {
-            transferArgs = this.dataArgsBuilder!.buildArgsForESDTTransfer(transfer);
+            dataParts = this.tokenTransfersDataBuilder!.buildDataPartsForESDTTransfer(transfer);
             extraGasForTransfer = this.config!.gasLimitESDTTransfer + BigInt(ADDITIONAL_GAS_FOR_ESDT_TRANSFER);
         } else {
-            transferArgs = this.dataArgsBuilder!.buildArgsForSingleESDTNFTTransfer(transfer, receiver);
+            dataParts = this.tokenTransfersDataBuilder!.buildDataPartsForSingleESDTNFTTransfer(transfer, receiver);
             extraGasForTransfer = this.config!.gasLimitESDTNFTTransfer + BigInt(ADDITIONAL_GAS_FOR_ESDT_NFT_TRANSFER);
             receiver = options.sender;
         }
@@ -361,7 +361,7 @@ export class TransferTransactionsFactory {
             config: this.config!,
             sender: options.sender,
             receiver: receiver,
-            dataParts: transferArgs,
+            dataParts: dataParts,
             gasLimit: extraGasForTransfer,
             addDataMovementGas: true,
         }).build();

--- a/src/utils.codec.ts
+++ b/src/utils.codec.ts
@@ -16,11 +16,6 @@ export function numberToPaddedHex(value: bigint | number | BigNumber.Value) {
     return zeroPadStringIfOddLength(hex);
 }
 
-export function numberToPaddedHexWithZeroAsEmptyString(value: bigint | number | BigNumber.Value) {
-    const paddedHex = numberToPaddedHex(value);
-    return paddedHex == "00" ? "" : paddedHex;
-}
-
 export function isPaddedHex(input: string) {
     input = input || "";
     let decodedThenEncoded = Buffer.from(input, "hex").toString("hex");

--- a/src/utils.codec.ts
+++ b/src/utils.codec.ts
@@ -16,6 +16,11 @@ export function numberToPaddedHex(value: bigint | number | BigNumber.Value) {
     return zeroPadStringIfOddLength(hex);
 }
 
+export function numberToPaddedHexWithZeroAsEmptyString(value: bigint | number | BigNumber.Value) {
+    const paddedHex = numberToPaddedHex(value);
+    return paddedHex == "00" ? "" : paddedHex;
+}
+
 export function isPaddedHex(input: string) {
     input = input || "";
     let decodedThenEncoded = Buffer.from(input, "hex").toString("hex");


### PR DESCRIPTION
Regression (v13): when the interaction API was used to create a transfer & execute transaction, in conjunction with `contract.methods.foobar()` , the code asked for the endpoint definition of the transfer builtin function (e.g. ESDTTransfer)  - unexpected / undesired.

Code is changed to directly use a `SmartContractTransactionsFactory` within `Interaction.buildTransaction()` - a factory without an ABI (not necessary, arguments are already typed when instantiating an `Interaction`).

An extra extremely minor (perhaps not significant) regression is fixed, as well: a zero token nonce (e.g. for fungible tokens) is now encoded as `""` (as in v12) in case of transfer & execute - instead of `"00"`.