### PR TITLE
Analyze serialization of variadic arguments (v12 vs v13)

### DIFF
--- a/src/smartcontracts/nativeSerializer.spec.ts
+++ b/src/smartcontracts/nativeSerializer.spec.ts
@@ -438,6 +438,47 @@ describe("test native serializer", () => {
         assert.deepEqual(typedValues[2].getType(), enumType);
         assert.deepEqual(typedValues[2].valueOf(), { name: 'Something', fields: [new Address('erd1dc3yzxxeq69wvf583gw0h67td226gu2ahpk3k50qdgzzym8npltq7ndgha')] });
         assert.deepEqual(typedValues[3].getType(), enumType);
-        assert.deepEqual(typedValues[3].valueOf(), { name: 'Else', fields: [new BigNumber(42), new BigNumber(43)] });
+        assert.deepEqual(typedValues[3].valueOf(), { name: "Else", fields: [new BigNumber(42), new BigNumber(43)] });
+    });
+
+    it.only("issue 435", async () => {
+        const abi = AbiRegistry.create({
+            endpoints: [
+                {
+                    name: "foo",
+                    inputs: [
+                        {
+                            type: "optional<variadic<MyEnum>>",
+                        },
+                    ],
+                    outputs: [],
+                },
+            ],
+            types: {
+                MyEnum: {
+                    type: "enum",
+                    variants: [
+                        {
+                            name: "a",
+                            discriminant: 0,
+                        },
+                        {
+                            name: "b",
+                            discriminant: 1,
+                        },
+                        {
+                            name: "c",
+                            discriminant: 2,
+                        },
+                    ],
+                },
+            },
+        });
+
+        const endpoint = abi.getEndpoint("foo");
+
+        NativeSerializer.nativeToTypedValues([], endpoint);
+        NativeSerializer.nativeToTypedValues([["a"]], endpoint);
+        NativeSerializer.nativeToTypedValues([[0]], endpoint);
     });
 });

--- a/src/smartcontracts/nativeSerializer.spec.ts
+++ b/src/smartcontracts/nativeSerializer.spec.ts
@@ -518,4 +518,68 @@ describe("test native serializer", () => {
         assert.deepEqual(typedValues[3].getType(), enumType);
         assert.deepEqual(typedValues[3].valueOf(), { name: "Else", fields: [new BigNumber(42), new BigNumber(43)] });
     });
+
+    it("should getArgumentsCardinality", async () => {
+        const abi = AbiRegistry.create({
+            endpoints: [
+                {
+                    name: "a",
+                    inputs: [
+                        {
+                            type: "u8",
+                        },
+                    ],
+                },
+                {
+                    name: "b",
+                    inputs: [
+                        {
+                            type: "variadic<u8>",
+                        },
+                    ],
+                },
+                {
+                    name: "c",
+                    inputs: [
+                        {
+                            type: "optional<u8>",
+                        },
+                    ],
+                },
+                {
+                    name: "d",
+                    inputs: [
+                        {
+                            type: "optional<variadic<u8>>",
+                        },
+                    ],
+                },
+            ],
+        });
+
+        assert.deepEqual(NativeSerializer.getArgumentsCardinality(abi.getEndpoint("a").input), {
+            min: 1,
+            max: 1,
+            variadic: false,
+        });
+
+        assert.deepEqual(NativeSerializer.getArgumentsCardinality(abi.getEndpoint("b").input), {
+            min: 0,
+            max: Infinity,
+            variadic: true,
+        });
+
+        assert.deepEqual(NativeSerializer.getArgumentsCardinality(abi.getEndpoint("c").input), {
+            min: 0,
+            max: 1,
+            variadic: false,
+        });
+
+        assert.deepEqual(NativeSerializer.getArgumentsCardinality(abi.getEndpoint("d").input), {
+            min: 0,
+            max: 1,
+            // This is somehow a limitation of the current implementation.
+            variadic: false,
+        });
+    });
 });

--- a/src/smartcontracts/nativeSerializer.ts
+++ b/src/smartcontracts/nativeSerializer.ts
@@ -1,14 +1,67 @@
+/* eslint-disable @typescript-eslint/no-namespace */
 import BigNumber from "bignumber.js";
 import { Address } from "../address";
 import { ErrInvalidArgument } from "../errors";
 import { IAddress } from "../interface";
 import { numberToPaddedHex } from "../utils.codec";
 import { ArgumentErrorContext } from "./argumentErrorContext";
-import { AddressType, AddressValue, BigIntType, BigIntValue, BigUIntType, BigUIntValue, BooleanType, BooleanValue, BytesType, BytesValue, CompositeType, CompositeValue, EndpointDefinition, EndpointParameterDefinition, EnumType, EnumValue, Field, I16Type, I16Value, I32Type, I32Value, I64Type, I64Value, I8Type, I8Value, List, ListType, NumericalType, OptionalType, OptionalValue, OptionType, OptionValue, PrimitiveType, Struct, StructType, TokenIdentifierType, TokenIdentifierValue, Tuple, TupleType, Type, TypedValue, U16Type, U16Value, U32Type, U32Value, U64Type, U64Value, U8Type, U8Value, VariadicType, VariadicValue } from "./typesystem";
+import {
+    AddressType,
+    AddressValue,
+    BigIntType,
+    BigIntValue,
+    BigUIntType,
+    BigUIntValue,
+    BooleanType,
+    BooleanValue,
+    BytesType,
+    BytesValue,
+    CompositeType,
+    CompositeValue,
+    EndpointDefinition,
+    EndpointParameterDefinition,
+    EnumType,
+    EnumValue,
+    Field,
+    I16Type,
+    I16Value,
+    I32Type,
+    I32Value,
+    I64Type,
+    I64Value,
+    I8Type,
+    I8Value,
+    List,
+    ListType,
+    NumericalType,
+    OptionalType,
+    OptionalValue,
+    OptionType,
+    OptionValue,
+    PrimitiveType,
+    Struct,
+    StructType,
+    TokenIdentifierType,
+    TokenIdentifierValue,
+    Tuple,
+    TupleType,
+    Type,
+    TypedValue,
+    U16Type,
+    U16Value,
+    U32Type,
+    U32Value,
+    U64Type,
+    U64Value,
+    U8Type,
+    U8Value,
+    VariadicType,
+    VariadicValue,
+} from "./typesystem";
 
 export namespace NativeTypes {
     export type NativeBuffer = Buffer | string;
-    export type NativeBytes = Buffer | { valueOf(): Buffer; } | string;
+    export type NativeBytes = Buffer | { valueOf(): Buffer } | string;
     export type NativeAddress = string | Buffer | IAddress | { getAddress(): IAddress };
 }
 
@@ -46,7 +99,9 @@ export namespace NativeSerializer {
         const { min, max } = getArgumentsCardinality(endpoint.input);
 
         if (!(min <= args.length && args.length <= max)) {
-            throw new ErrInvalidArgument(`Wrong number of arguments for endpoint ${endpoint.name}: expected between ${min} and ${max} arguments, have ${args.length}`);
+            throw new ErrInvalidArgument(
+                `Wrong number of arguments for endpoint ${endpoint.name}: expected between ${min} and ${max} arguments, have ${args.length}`,
+            );
         }
     }
 
@@ -67,7 +122,9 @@ export namespace NativeSerializer {
         if (argAtIndex?.belongsToTypesystem) {
             const isVariadicValue = argAtIndex.hasClassOrSuperclass(VariadicValue.ClassName);
             if (!isVariadicValue) {
-                throw new ErrInvalidArgument(`Wrong argument type for endpoint ${endpoint.name}: typed value provided; expected variadic type, have ${argAtIndex.getClassName()}`);
+                throw new ErrInvalidArgument(
+                    `Wrong argument type for endpoint ${endpoint.name}: typed value provided; expected variadic type, have ${argAtIndex.getClassName()}`,
+                );
             }
 
             // Do not repack.
@@ -82,21 +139,31 @@ export namespace NativeSerializer {
     // f(arg1, arg2, optional<arg3>, optional<arg4>) returns { min: 2, max: 4, variadic: false }
     // f(arg1, variadic<bytes>) returns { min: 1, max: Infinity, variadic: true }
     // f(arg1, arg2, optional<arg3>, arg4, optional<arg5>, variadic<bytes>) returns { min: 2, max: Infinity, variadic: true }
-    function getArgumentsCardinality(parameters: EndpointParameterDefinition[]): { min: number, max: number, variadic: boolean } {
+    export function getArgumentsCardinality(parameters: EndpointParameterDefinition[]): {
+        min: number;
+        max: number;
+        variadic: boolean;
+    } {
         let reversed = [...parameters].reverse(); // keep the original unchanged
         let min = parameters.length;
         let max = parameters.length;
         let variadic = false;
+
         if (reversed.length > 0 && reversed[0].type.getCardinality().isComposite()) {
             max = Infinity;
             variadic = true;
         }
+
         for (let parameter of reversed) {
+            // It's a single-value, not a multi-value parameter. Thus, cardinality isn't affected.
             if (parameter.type.getCardinality().isSingular()) {
                 break;
             }
+
+            // It's a multi-value parameter: optional, variadic etc.
             min -= 1;
         }
+
         return { min, max, variadic };
     }
 
@@ -154,7 +221,9 @@ export namespace NativeSerializer {
 
     function toVariadicValue(native: any, type: VariadicType, errorContext: ArgumentErrorContext): TypedValue {
         if (type.isCounted) {
-            throw new ErrInvalidArgument(`Counted variadic arguments must be explicitly typed. E.g. use "VariadicValue.fromItemsCounted()" or "new VariadicValue()"`);
+            throw new ErrInvalidArgument(
+                `Counted variadic arguments must be explicitly typed. E.g. use "VariadicValue.fromItemsCounted()" or "new VariadicValue()"`,
+            );
         }
 
         if (native == null) {
@@ -278,7 +347,7 @@ export namespace NativeSerializer {
             return new BytesValue(innerValue);
         }
         if (typeof innerValue === "number") {
-            return BytesValue.fromHex(numberToPaddedHex(innerValue))
+            return BytesValue.fromHex(numberToPaddedHex(innerValue));
         }
 
         errorContext.convertError(native, "BytesValue");
@@ -299,7 +368,10 @@ export namespace NativeSerializer {
     }
 
     // TODO: move logic to typesystem/address.ts
-    export function convertNativeToAddress(native: NativeTypes.NativeAddress, errorContext: ArgumentErrorContext): IAddress {
+    export function convertNativeToAddress(
+        native: NativeTypes.NativeAddress,
+        errorContext: ArgumentErrorContext,
+    ): IAddress {
         if ((<any>native).bech32) {
             return <IAddress>native;
         }

--- a/src/smartcontracts/smartContract.spec.ts
+++ b/src/smartcontracts/smartContract.spec.ts
@@ -13,7 +13,7 @@ import { TransactionWatcher } from "../transactionWatcher";
 import { Code } from "./code";
 import { ContractFunction } from "./function";
 import { SmartContract } from "./smartContract";
-import { U32Value } from "./typesystem";
+import { AbiRegistry, OptionalValue, U32Value, U8Value, VariadicValue } from "./typesystem";
 import { BytesValue } from "./typesystem/bytes";
 
 describe("test contract", () => {
@@ -195,5 +195,72 @@ describe("test contract", () => {
         ]);
 
         assert.isTrue((await provider.getTransactionStatus(hash)).isExecuted());
+    });
+
+    it("should be stricter than v12 on optional<variadic> (exotic) parameters (since NativeSerializer is used under the hood)", async () => {
+        // Related to: https://github.com/multiversx/mx-sdk-js-core/issues/435.
+        // In v12, contract.call() only supported TypedValue[] as contract call arguments.
+        // In v13, NativeSerializer is used under the hood, which allows one to mix typed values with native values.
+        // However, this comes with additional rules regarding optional<variadic<?>> parameters.
+        // These parameters are exotic and, generally speaking, can be avoided in contracts:
+        // https://docs.multiversx.com/developers/data/multi-values/
+
+        const abi = AbiRegistry.create({
+            endpoints: [
+                {
+                    name: "foo",
+                    inputs: [
+                        {
+                            type: "optional<variadic<u8>>",
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const endpointFoo = abi.getEndpoint("foo");
+        const callerAddress = Address.fromBech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+        const contractAddress = Address.fromBech32("erd1qqqqqqqqqqqqqpgqaxa53w6uk43n6dhyt2la6cd5lyv32qn4396qfsqlnk");
+
+        const contract = new SmartContract({
+            abi,
+            address: contractAddress,
+        });
+
+        // This was possible in v12 (more permissive).
+        // In v12, contract.call() required TypedValue[] for "args".
+        assert.throws(() => {
+            contract.call({
+                func: "foo",
+                args: [new U8Value(1), new U8Value(2), new U8Value(3)],
+                chainID: "D",
+                gasLimit: 1000000,
+                caller: callerAddress,
+            });
+        }, "Wrong number of arguments for endpoint foo: expected between 0 and 1 arguments, have 3");
+
+        // In v13, the contract.call() would be as follows:
+        contract.call({
+            func: "foo",
+            args: [[new U8Value(1), new U8Value(2), new U8Value(3)]],
+            chainID: "D",
+            gasLimit: 1000000,
+            caller: callerAddress,
+        });
+
+        // This did not work in v12, it does not work in v13 either (since it's imprecise / incorrect).
+        assert.throws(() => {
+            contract.methods.foo([1, 2, 3]);
+        }, "Wrong number of arguments for endpoint foo: expected between 0 and 1 arguments, have 3");
+
+        const optionalVariadicType = endpointFoo.input[0].type;
+        const variadicTypedValue = VariadicValue.fromItems(new U8Value(1), new U8Value(2), new U8Value(3));
+
+        // However, all these were and are still possible:
+        contract.methodsExplicit.foo([new U8Value(1), new U8Value(2), new U8Value(3)]);
+        contract.methods.foo([new OptionalValue(optionalVariadicType, variadicTypedValue)]);
+        contract.methods.foo([variadicTypedValue]);
+        contract.methods.foo([[new U8Value(1), new U8Value(2), new U8Value(3)]]);
+        contract.methods.foo([[new U8Value(1), 2, 3]]);
     });
 });


### PR DESCRIPTION
Follow-up of https://github.com/multiversx/mx-sdk-js-core/issues/435.

In v13, some client code that deals with Smart Contract calls **might be affected by an unforeseen breaking (but minor) change**.

**Circumstances (affected code):**
 - the client code uses `SmartContract.call()` to prepare transactions
 - the client code passes the `abi` to the `SmartContract` (when creating an instance)
 - the client code calls a Smart Contract endpoint that is _**variadic**_.


**Solutions:**
 - do not pass the `abi` parameter when creating the `SmartContract` object
 - OR adjust variadic arguments as depicted in the comments (below)
 - OR switch to using one of the new approaches (v13) of creating smart contract calls

**Code that isn't affected:**
 - code that uses `SmartContract.methods.myFunction()` to prepare a contract call
 - code that uses `SmartContract.methodsExplicit.myFunction()` to prepare a contract call

**Under-the-hood differences:**
 - in v12, `SmartContract.call()` only accepted `TypedValue` objects as `args`.
 - in v13, `SmartContract.call()` accepts a mixture of `TypedValue` objects and native JavaScript values / objects as `args`. This makes use of the `NativeSerializer` component, under the hood. This causes the unforeseen breaking (but minor) change.

**Additional notes:**

In `sdk-core v13`, the recommended way to create transactions for deploying, upgrading and interacting with smart contracts is through a [`SmartContractTransactionsFactory`](https://multiversx.github.io/mx-sdk-js-core/v13/classes/SmartContractTransactionsFactory.html). The older (legacy) approaches are still available, however.

 - https://docs.multiversx.com/sdk-and-tools/sdk-js/sdk-js-cookbook-v13/#contract-interactions
 - https://docs.multiversx.com/sdk-and-tools/sdk-js/sdk-js-cookbook-v13/#contract-deployments
 - https://docs.multiversx.com/sdk-and-tools/sdk-js/sdk-js-cookbook-v13/#contract-queries