### PR TITLE
Handle "upgradeConstructor" of ABI.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.1.1",
+  "version": "13.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "13.1.1",
+      "version": "13.2.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "13.1.0",
+      "version": "13.1.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.1.1",
+  "version": "13.2.0",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -150,8 +150,11 @@ export class AbiRegistry {
             throw new errors.ErrTypingSystem("Did not re-map all custom types");
         }
 
-        // Let's remap the constructor:
+        // Let's remap the constructor(s):
         const newConstructor = mapEndpoint(this.constructorDefinition, mapper);
+        const newUpgradeConstructor = this.upgradeConstructorDefinition
+            ? mapEndpoint(this.upgradeConstructorDefinition, mapper)
+            : undefined;
 
         // Then, remap types of all endpoint parameters.
         // The mapper learned all necessary types in the previous step.
@@ -167,6 +170,7 @@ export class AbiRegistry {
         const newRegistry = new AbiRegistry({
             name: this.name,
             constructorDefinition: newConstructor,
+            upgradeConstructorDefinition: newUpgradeConstructor,
             endpoints: newEndpoints,
             customTypes: newCustomTypes,
             events: newEvents,

--- a/src/smartcontracts/typesystem/abiRegistry.ts
+++ b/src/smartcontracts/typesystem/abiRegistry.ts
@@ -12,6 +12,7 @@ const interfaceNamePlaceholder = "?";
 export class AbiRegistry {
     readonly name: string;
     readonly constructorDefinition: EndpointDefinition;
+    readonly upgradeConstructorDefinition?: EndpointDefinition;
     readonly endpoints: EndpointDefinition[] = [];
     readonly customTypes: CustomType[] = [];
     readonly events: EventDefinition[] = [];
@@ -19,12 +20,14 @@ export class AbiRegistry {
     private constructor(options: {
         name: string;
         constructorDefinition: EndpointDefinition;
+        upgradeConstructorDefinition?: EndpointDefinition;
         endpoints: EndpointDefinition[];
         customTypes: CustomType[];
         events?: EventDefinition[];
     }) {
         this.name = options.name;
         this.constructorDefinition = options.constructorDefinition;
+        this.upgradeConstructorDefinition = options.upgradeConstructorDefinition;
         this.endpoints = options.endpoints;
         this.customTypes = options.customTypes;
         this.events = options.events || [];
@@ -33,18 +36,25 @@ export class AbiRegistry {
     static create(options: {
         name?: string;
         constructor?: any;
+        upgradeConstructor?: any;
         endpoints?: any[];
         types?: Record<string, any>;
         events?: any[];
     }): AbiRegistry {
         const name = options.name || interfaceNamePlaceholder;
         const constructor = options.constructor || {};
+        const upgradeConstructor = options.upgradeConstructor || {};
         const endpoints = options.endpoints || [];
         const types = options.types || {};
         const events = options.events || [];
 
         // Load arbitrary input parameters into properly-defined objects (e.g. EndpointDefinition and CustomType).
         const constructorDefinition = EndpointDefinition.fromJSON({ name: "constructor", ...constructor });
+        const upgradeConstructorDefinition = EndpointDefinition.fromJSON({
+            name: "upgradeConstructor",
+            ...upgradeConstructor,
+        });
+
         const endpointDefinitions = endpoints.map((item) => EndpointDefinition.fromJSON(item));
         const customTypes: CustomType[] = [];
 
@@ -65,6 +75,7 @@ export class AbiRegistry {
         const registry = new AbiRegistry({
             name: name,
             constructorDefinition: constructorDefinition,
+            upgradeConstructorDefinition: upgradeConstructorDefinition,
             endpoints: endpointDefinitions,
             customTypes: customTypes,
             events: eventDefinitions,

--- a/src/testdata/adder.abi.json
+++ b/src/testdata/adder.abi.json
@@ -1,20 +1,20 @@
 {
     "buildInfo": {
         "rustc": {
-            "version": "1.71.0-nightly",
-            "commitHash": "a2b1646c597329d0a25efa3889b66650f65de1de",
-            "commitDate": "2023-05-25",
+            "version": "1.76.0-nightly",
+            "commitHash": "d86d65bbc19b928387f68427fcc3a0da498d8a19",
+            "commitDate": "2023-12-10",
             "channel": "Nightly",
-            "short": "rustc 1.71.0-nightly (a2b1646c5 2023-05-25)"
+            "short": "rustc 1.76.0-nightly (d86d65bbc 2023-12-10)"
         },
         "contractCrate": {
             "name": "adder",
             "version": "0.0.0",
-            "gitVersion": "v0.45.2.1-reproducible-169-g37d970c"
+            "gitVersion": "v0.50.1-3-gbed74682a"
         },
         "framework": {
             "name": "multiversx-sc",
-            "version": "0.47.2"
+            "version": "0.50.1"
         }
     },
     "docs": [
@@ -23,6 +23,15 @@
     ],
     "name": "Adder",
     "constructor": {
+        "inputs": [
+            {
+                "name": "initial_value",
+                "type": "BigUint"
+            }
+        ],
+        "outputs": []
+    },
+    "upgradeConstructor": {
         "inputs": [
             {
                 "name": "initial_value",
@@ -43,25 +52,9 @@
             ]
         },
         {
-            "name": "upgrade",
-            "mutability": "mutable",
-            "inputs": [
-                {
-                    "name": "new_value",
-                    "type": "BigUint"
-                }
-            ],
-            "outputs": []
-        },
-        {
-            "docs": [
-                "Add desired amount to the storage variable."
-            ],
+            "docs": ["Add desired amount to the storage variable."],
             "name": "add",
             "mutability": "mutable",
-            "payableInTokens": [
-                "*"
-            ],
             "inputs": [
                 {
                     "name": "value",

--- a/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
+++ b/src/transactionsFactories/smartContractTransactionsFactory.spec.ts
@@ -401,7 +401,7 @@ describe("test smart contract transactions factory", function () {
             contract: receiver,
             bytecode: bytecode,
             gasLimit: gasLimit,
-            arguments: [new U32Value(42), new U32Value(42), new U32Value(42)],
+            arguments: [42, 42, 42],
         });
 
         assert.equal(Buffer.from(tx1.data!).toString(), `upgradeContract@abba@0504@2a@2a@2a`);
@@ -414,7 +414,7 @@ describe("test smart contract transactions factory", function () {
             contract: receiver,
             bytecode: bytecode,
             gasLimit: gasLimit,
-            arguments: [new U32Value(42), new U32Value(42)],
+            arguments: [42, 42],
         });
 
         assert.equal(Buffer.from(tx2.data!).toString(), `upgradeContract@abba@0504@2a@2a`);
@@ -427,10 +427,25 @@ describe("test smart contract transactions factory", function () {
             contract: receiver,
             bytecode: bytecode,
             gasLimit: gasLimit,
-            arguments: [new U32Value(42)],
+            arguments: [42],
         });
 
         assert.equal(Buffer.from(tx3.data!).toString(), `upgradeContract@abba@0504@2a`);
+
+        // No fallbacks.
+        (<any>abi).constructorDefinition = undefined;
+
+        assert.throws(
+            () =>
+                factory.createTransactionForUpgrade({
+                    sender: sender,
+                    contract: receiver,
+                    bytecode: bytecode,
+                    gasLimit: gasLimit,
+                    arguments: [42],
+                }),
+            "Can't convert args to TypedValues",
+        );
     });
 
     it("should create 'Transaction' for claiming developer rewards", async function () {

--- a/src/transactionsFactories/smartContractTransactionsFactory.ts
+++ b/src/transactionsFactories/smartContractTransactionsFactory.ts
@@ -21,6 +21,7 @@ interface IConfig {
 
 interface IAbi {
     constructorDefinition: EndpointDefinition;
+    upgradeConstructorDefinition?: EndpointDefinition;
 
     getEndpoint(name: string | ContractFunction): EndpointDefinition;
 }
@@ -169,6 +170,10 @@ export class SmartContractTransactionsFactory {
     private getEndpointForUpgrade(): EndpointDefinition | undefined {
         if (!this.abi) {
             return undefined;
+        }
+
+        if (this.abi.upgradeConstructorDefinition) {
+            return this.abi.upgradeConstructorDefinition;
         }
 
         try {


### PR DESCRIPTION
Will fix https://github.com/multiversx/mx-sdk-js-core/issues/449.

Order of priority:
1. "upgradeConstructor", if available
2. "upgrade" endpoint, if available
3. "constructor", if available