### PR TITLE
Fix AddressValue to accept custom HRPs

### DIFF
--- a/src/smartcontracts/typesystem/address.ts
+++ b/src/smartcontracts/typesystem/address.ts
@@ -23,7 +23,7 @@ export class AddressValue extends PrimitiveValue {
 
     constructor(value: IAddress) {
         super(new AddressType());
-        this.value = new Address(value.bech32());
+        this.value = Address.newFromBech32(value.bech32());
     }
 
     getClassName(): string {


### PR DESCRIPTION
AddressValue currently throws the following when providing an address with custom human-readable parts:

`ErrAddressBadHrp ErrAddressBadHrp [Error]: Wrong address HRP. Expected: erd, got xyz`