### PR TITLE
Legacy ResultsParser: change access modifier of methods from private to protected

### DIFF
--- a/src/smartcontracts/resultsParser.ts
+++ b/src/smartcontracts/resultsParser.ts
@@ -196,7 +196,7 @@ export class ResultsParser {
         throw new ErrCannotParseContractResults(`transaction ${transaction.hash.toString()}`);
     }
 
-    private parseTransactionMetadata(transaction: ITransactionOnNetwork): TransactionMetadata {
+    protected parseTransactionMetadata(transaction: ITransactionOnNetwork): TransactionMetadata {
         return new TransactionDecoder().getTransactionMetadata({
             sender: transaction.sender.bech32(),
             receiver: transaction.receiver.bech32(),
@@ -205,7 +205,7 @@ export class ResultsParser {
         });
     }
 
-    private createBundleOnSimpleMoveBalance(transaction: ITransactionOnNetwork): UntypedOutcomeBundle | null {
+    protected createBundleOnSimpleMoveBalance(transaction: ITransactionOnNetwork): UntypedOutcomeBundle | null {
         let noResults = transaction.contractResults.items.length == 0;
         let noLogs = transaction.logs.events.length == 0;
 
@@ -220,7 +220,7 @@ export class ResultsParser {
         return null;
     }
 
-    private createBundleOnInvalidTransaction(transaction: ITransactionOnNetwork): UntypedOutcomeBundle | null {
+    protected createBundleOnInvalidTransaction(transaction: ITransactionOnNetwork): UntypedOutcomeBundle | null {
         if (transaction.status.isInvalid()) {
             if (transaction.receipt.data) {
                 return {
@@ -236,7 +236,7 @@ export class ResultsParser {
         return null;
     }
 
-    private createBundleOnEasilyFoundResultWithReturnData(results: IContractResults): UntypedOutcomeBundle | null {
+    protected createBundleOnEasilyFoundResultWithReturnData(results: IContractResults): UntypedOutcomeBundle | null {
         let resultItemWithReturnData = results.items.find(
             (item) => item.nonce.valueOf() != 0 && item.data.startsWith("@"),
         );
@@ -254,7 +254,7 @@ export class ResultsParser {
         };
     }
 
-    private createBundleOnSignalError(logs: ITransactionLogs): UntypedOutcomeBundle | null {
+    protected createBundleOnSignalError(logs: ITransactionLogs): UntypedOutcomeBundle | null {
         let eventSignalError = logs.findSingleOrNoneEvent(WellKnownEvents.OnSignalError);
         if (!eventSignalError) {
             return null;
@@ -271,7 +271,7 @@ export class ResultsParser {
         };
     }
 
-    private createBundleOnTooMuchGasWarning(logs: ITransactionLogs): UntypedOutcomeBundle | null {
+    protected createBundleOnTooMuchGasWarning(logs: ITransactionLogs): UntypedOutcomeBundle | null {
         let eventTooMuchGas = logs.findSingleOrNoneEvent(
             WellKnownEvents.OnWriteLog,
             (event) =>
@@ -294,7 +294,7 @@ export class ResultsParser {
         };
     }
 
-    private createBundleOnWriteLogWhereFirstTopicEqualsAddress(
+    protected createBundleOnWriteLogWhereFirstTopicEqualsAddress(
         logs: ITransactionLogs,
         address: IAddress,
     ): UntypedOutcomeBundle | null {
@@ -329,7 +329,7 @@ export class ResultsParser {
         return null;
     }
 
-    private createBundleWithFallbackHeuristics(
+    protected createBundleWithFallbackHeuristics(
         transaction: ITransactionOnNetwork,
         transactionMetadata: TransactionMetadata,
     ): UntypedOutcomeBundle | null {


### PR DESCRIPTION
Part of #491.

In some cases, client code might still require to use a (custom) variant of the legacy `ResultsParser`. Allow one to override its functions, if needed.