### PR TITLE
Temporary workaround (hotfix): do not call "extendUserAgent"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.14.0",
+  "version": "13.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-core",
-      "version": "13.14.0",
+      "version": "13.14.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-core",
-  "version": "13.14.0",
+  "version": "13.14.1",
   "description": "MultiversX SDK for JavaScript and TypeScript",
   "author": "MultiversX",
   "homepage": "https://multiversx.com",

--- a/src/networkProviders/apiNetworkProvider.ts
+++ b/src/networkProviders/apiNetworkProvider.ts
@@ -34,7 +34,6 @@ export class ApiNetworkProvider implements INetworkProvider {
         this.config = { ...defaultAxiosConfig, ...config };
         this.backingProxyNetworkProvider = new ProxyNetworkProvider(url, proxyConfig);
         this.axios = getAxios();
-        extendUserAgent(this.userAgentPrefix, this.config);
     }
 
     private getProxyConfig(config: NetworkProviderConfig | undefined) {

--- a/src/networkProviders/providers.dev.net.spec.ts
+++ b/src/networkProviders/providers.dev.net.spec.ts
@@ -42,7 +42,7 @@ describe("test network providers on devnet: Proxy and API", function () {
         assert.deepEqual(apiResponse, proxyResponse);
     });
 
-    it("should add userAgent unknown for clientName when no clientName passed", async function () {
+    it.skip("should add userAgent unknown for clientName when no clientName passed", async function () {
         const expectedApiUserAgent = "multiversx-sdk/api/unknown";
         const expectedProxyUserAgent = "multiversx-sdk/proxy/unknown";
 
@@ -55,7 +55,7 @@ describe("test network providers on devnet: Proxy and API", function () {
         assert.equal(localProxyProvider.config.headers.getUserAgent(), expectedProxyUserAgent);
     });
 
-    it("should set userAgent with specified clientName ", async function () {
+    it.skip("should set userAgent with specified clientName ", async function () {
         const expectedApiUserAgent = "multiversx-sdk/api/test";
         const expectedProxyUserAgent = "multiversx-sdk/proxy/test";
 
@@ -72,7 +72,7 @@ describe("test network providers on devnet: Proxy and API", function () {
         assert.equal(localProxyProvider.config.headers.getUserAgent(), expectedProxyUserAgent);
     });
 
-    it("should keep the set userAgent and add the sdk to it", async function () {
+    it.skip("should keep the set userAgent and add the sdk to it", async function () {
         const expectedApiUserAgent = "Client-info multiversx-sdk/api/test";
         const expectedProxyUserAgent = "Client-info multiversx-sdk/proxy/test";
 

--- a/src/networkProviders/proxyNetworkProvider.ts
+++ b/src/networkProviders/proxyNetworkProvider.ts
@@ -28,7 +28,6 @@ export class ProxyNetworkProvider implements INetworkProvider {
         this.url = url;
         this.config = { ...defaultAxiosConfig, ...config };
         this.axios = getAxios();
-        extendUserAgent(this.userAgentPrefix, this.config);
     }
 
     async getNetworkConfig(): Promise<NetworkConfig> {


### PR DESCRIPTION
Temporary workaround (hotfix): do not call `extendUserAgent`, until a complete solution is found.