### PR TITLE
Fix contract results parsing

### DIFF
--- a/src/smartContracts/smartContractTransactionsOutcomeParser.spec.ts
+++ b/src/smartContracts/smartContractTransactionsOutcomeParser.spec.ts
@@ -93,7 +93,7 @@ describe("test smart contract transactions outcome parser", () => {
         const transactionOnNetwork = new TransactionOnNetwork({
             nonce: 7n,
             function: "getUltimateAnswer",
-            smartContractResults: [new SmartContractResult({ data: Buffer.from("@6f6b@2a") })],
+            smartContractResults: [new SmartContractResult({ data: Buffer.from("QDZmNmJAMmE=", "base64") })],
         });
 
         const parsed = parser.parseExecute({ transactionOnNetwork });

--- a/src/smartContracts/smartContractTransactionsOutcomeParser.ts
+++ b/src/smartContracts/smartContractTransactionsOutcomeParser.ts
@@ -142,7 +142,7 @@ export class SmartContractTransactionsOutcomeParser {
         const eligibleResults: SmartContractResult[] = [];
 
         for (const result of transactionOnNetwork.smartContractResults) {
-            const matchesCriteriaOnData = result.data.toString().startsWith(ARGUMENTS_SEPARATOR);
+            const matchesCriteriaOnData = Buffer.from(result.data).toString("utf-8").startsWith(ARGUMENTS_SEPARATOR);
             const matchesCriteriaOnReceiver = result.receiver.toBech32() === transactionOnNetwork.sender.toBech32();
             const matchesCriteriaOnPreviousHash = result;
 


### PR DESCRIPTION
Test incorrectly assumes that contract results are returned in hex – it's base64 instead.

Quick debugging insight showcasing the invalid base64 <> hex comparison:

<img width="409" alt="Screenshot 2025-05-04 at 11 44 05 PM" src="https://github.com/user-attachments/assets/908821d9-2046-4965-9612-bd9416f08fe0" />