### PR TITLE
Allow passing network options from Entrypoint to Network Provider

### DIFF
--- a/src/entrypoints/entrypoints.ts
+++ b/src/entrypoints/entrypoints.ts
@@ -16,7 +16,7 @@ import { GasLimitEstimator } from "../gasEstimator";
 import { GovernanceController, GovernanceTransactionsFactory } from "../governance";
 import { MultisigTransactionsFactory } from "../multisig";
 import { MultisigController } from "../multisig/multisigController";
-import { ApiNetworkProvider, ProxyNetworkProvider } from "../networkProviders";
+import { ApiNetworkProvider, NetworkProviderConfig, ProxyNetworkProvider } from "../networkProviders";
 import { INetworkProvider } from "../networkProviders/interface";
 import { SmartContractTransactionsFactory } from "../smartContracts";
 import { SmartContractController } from "../smartContracts/smartContractController";
@@ -34,19 +34,24 @@ export class NetworkEntrypoint {
     constructor(options: {
         networkProviderUrl: string;
         networkProviderKind: string;
+        networkProviderOptions?: NetworkProviderConfig;
         chainId: string;
         clientName?: string;
         withGasLimitEstimator?: boolean;
         gasLimitMultiplier?: number;
     }) {
+        options.networkProviderOptions = options.networkProviderOptions || {};
+
+        if (options.clientName) {
+            options.networkProviderOptions.clientName = options.clientName;
+        } else if (options.networkProviderOptions?.headers?.["User-Agent"]) {
+            options.networkProviderOptions.clientName = options.networkProviderOptions.headers["User-Agent"];
+        }
+
         if (options.networkProviderKind === "proxy") {
-            this.networkProvider = new ProxyNetworkProvider(options.networkProviderUrl, {
-                clientName: options.clientName,
-            });
+            this.networkProvider = new ProxyNetworkProvider(options.networkProviderUrl, options.networkProviderOptions);
         } else if (options.networkProviderKind === "api") {
-            this.networkProvider = new ApiNetworkProvider(options.networkProviderUrl, {
-                clientName: options.clientName,
-            });
+            this.networkProvider = new ApiNetworkProvider(options.networkProviderUrl, options.networkProviderOptions);
         } else {
             throw new ErrInvalidNetworkProviderKind();
         }
@@ -267,12 +272,14 @@ export class TestnetEntrypoint extends NetworkEntrypoint {
         clientName?: string;
         withGasLimitEstimator?: boolean;
         gasLimitMultiplier?: number;
+        networkProviderOptions?: NetworkProviderConfig;
     }) {
         const entrypointConfig = new TestnetEntrypointConfig();
         options = options || {};
         super({
             networkProviderUrl: options.url || entrypointConfig.networkProviderUrl,
             networkProviderKind: options.kind || entrypointConfig.networkProviderKind,
+            networkProviderOptions: options.networkProviderOptions,
             chainId: entrypointConfig.chainId,
             clientName: options.clientName,
             withGasLimitEstimator: options.withGasLimitEstimator,
@@ -288,12 +295,14 @@ export class DevnetEntrypoint extends NetworkEntrypoint {
         clientName?: string;
         withGasLimitEstimator?: boolean;
         gasLimitMultiplier?: number;
+        networkProviderOptions?: NetworkProviderConfig;
     }) {
         const entrypointConfig = new DevnetEntrypointConfig();
         options = options || {};
         super({
             networkProviderUrl: options.url || entrypointConfig.networkProviderUrl,
             networkProviderKind: options.kind || entrypointConfig.networkProviderKind,
+            networkProviderOptions: options.networkProviderOptions,
             chainId: entrypointConfig.chainId,
             clientName: options.clientName,
             withGasLimitEstimator: options.withGasLimitEstimator,
@@ -309,12 +318,14 @@ export class MainnetEntrypoint extends NetworkEntrypoint {
         clientName?: string;
         withGasLimitEstimator?: boolean;
         gasLimitMultiplier?: number;
+        networkProviderOptions?: NetworkProviderConfig;
     }) {
         const entrypointConfig = new MainnetEntrypointConfig();
         options = options || {};
         super({
             networkProviderUrl: options.url || entrypointConfig.networkProviderUrl,
             networkProviderKind: options.kind || entrypointConfig.networkProviderKind,
+            networkProviderOptions: options.networkProviderOptions,
             chainId: entrypointConfig.chainId,
             clientName: options.clientName,
             withGasLimitEstimator: options.withGasLimitEstimator,


### PR DESCRIPTION
Hello,

### Summary

This PR adds support for passing custom network options from the `Entrypoint` to the `Network Provider`. This allows developers to configure headers and other request-related parameters when initializing the entrypoint.

### Changes

- Added a new `networkProviderOptions` field in the Entrypoint options.
- Ensured `clientName` can be set via either `options.clientName` or fallback to `User-Agent` header.

### Motivation

Provides more flexibility for advanced developers needing to customize the network layer (e.g. for authentication, logging, or custom headers).